### PR TITLE
Issue#22 post subscription duplicates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2021, RWTH Aachen University, ' \
 author = 'EON EBC'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.5'
+release = '0.1.6'
 
 # The short X.Y version.
 version = '0.1'

--- a/filip/__init__.py
+++ b/filip/__init__.py
@@ -4,4 +4,4 @@ filip-Module. See readme or documentation for more information.
 from filip.config import settings
 from filip.clients.ngsi_v2 import HttpClient
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -885,13 +885,27 @@ class ContextBrokerClient(BaseHttpClient):
         Creates a new subscription. The subscription is represented by a
         Subscription object defined in filip.cb.models.
 
+        If the subscription already exists, the adding is prevented and the id
+        of the existing subscription is returned.
+
         Args:
-            subscription:
+            subscription: Subscription
 
         Returns:
-            object: 
+            str: Id of the created subscription
 
         """
+        existing_subscriptions = self.get_subscription_list()
+
+        sub_hash = str(subscription.dict(include={'subject', 'notification'}))
+        for ex_sub in existing_subscriptions:
+            if sub_hash ==\
+                    str(ex_sub.dict(include={'subject', 'notification'})):
+                self.logger.info("Subscription already exists, updated instead")
+                subscription.id = ex_sub.id
+                self.update_subscription(subscription)
+                return ex_sub.id
+
         url = urljoin(self.base_url, 'v2/subscriptions')
         headers = self.headers.copy()
         headers.update({'Content-Type': 'application/json'})

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ SETUP_REQUIRES = INSTALL_REQUIRES.copy()
 
 setuptools.setup(
     name='filip',
-    version='0.1.5',
+    version='0.1.6',
     author='RWTH Aachen University, E.ON Energy Research Center, Institute\
         of Energy Efficient Buildings and Indoor Climate',
     author_email='tstorek@eonerc.rwth-aachen.de',

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -294,6 +294,29 @@ class TestContextBroker(unittest.TestCase):
             self.assertNotEqual(sub_res.expires, sub_res_updated.expires)
             self.assertEqual(sub_res.id, sub_res_updated.id)
             self.assertGreaterEqual(sub_res_updated.expires, sub_res.expires)
+
+            # test duplicate prevention an update
+            sub = Subscription(**sub_example)
+            id1 = client.post_subscription(sub)
+            sub_first_version = client.get_subscription(id1)
+            sub.description = "This subscription shall not pass"
+            id2 = client.post_subscription(sub)
+            self.assertEqual(id1, id2)
+            sub_second_version = client.get_subscription(id2)
+            self.assertNotEqual(sub_first_version.description,
+                                sub_second_version.description)
+
+            # test that duplicate prevention does not prevent to much
+            sub2 = Subscription(**sub_example)
+            sub2.description = "Take this subscription to Fiware"
+            sub2.subject.entities[0] = {
+                            "idPattern": ".*",
+                            "type": "Building"
+                        }
+            id3 = client.post_subscription(sub2)
+            self.assertNotEqual(id1, id3)
+
+            # Clean up
             subs = client.get_subscription_list()
             for sub in subs:
                 client.delete_subscription(subscription_id=sub.id)
@@ -342,6 +365,7 @@ class TestContextBroker(unittest.TestCase):
         entity_after = client.get_entity(entity_id=entity_id,
                                          entity_type=entity_type)
         self.assertNotEqual(entity_before, entity_after)
+
 
     def tearDown(self) -> None:
         """


### PR DESCRIPTION
Finished the Issue.

If now a subscription with the same subject or notification is posted as an already existing subscription. The existing subscription is updated instead (description, expiration_time,... )

I did not use __eq__ in Subscription as the used comparision is quite specific.