### PR TITLE
Issue#34 Teardowns to remove subscriptions

### DIFF
--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -333,10 +333,7 @@ class TestContextBroker(unittest.TestCase):
             id3 = client.post_subscription(sub2)
             self.assertNotEqual(id1, id3)
 
-            # Clean up
-            subs = client.get_subscription_list()
-            for sub in subs:
-                client.delete_subscription(subscription_id=sub.id)
+
 
     def test_batch_operations(self):
         """
@@ -539,6 +536,10 @@ class TestContextBroker(unittest.TestCase):
             entities = [ContextEntity(id=entity.id, type=entity.type) for
                         entity in self.client.get_entity_list()]
             self.client.update(entities=entities, action_type='delete')
+
+            subs = self.client.get_subscription_list()
+            for sub in subs:
+                self.client.delete_subscription(subscription_id=sub.id)
         except RequestException:
             pass
 

--- a/tests/models/test_ngsi_v2_context.py
+++ b/tests/models/test_ngsi_v2_context.py
@@ -239,3 +239,14 @@ class TestContextModels(unittest.TestCase):
             NamedContextMetadata(name=string)
             ContextAttribute(type=string)
             ContextEntityKeyValues(id=string, type=string)
+
+    def tearDown(self) -> None:
+        """
+        Cleanup test server
+        """
+        fiware_header = FiwareHeader(service='filip',
+                                     service_path='/testing')
+        with ContextBrokerClient(fiware_header=fiware_header) as client:
+            sub_ids = [sub.id for sub in client.get_subscription_list()]
+            for sub_id in sub_ids:
+                client.delete_subscription(subscription_id=sub_id)


### PR DESCRIPTION
Added proper tear-downs to remove the subscriptions, to ensure that even in case of a test failure the state is cleaned. 

Could not resolve the failing tests in the CI/CD pipeline, locally the always work.

It could be observed that the tests do not fail always in the pipeline the subscription test in test_ngsi_v2_context.py fails rarley and if it shows a very strange behavior of missing one optional data field in the subscription entity.

The subscription test in test_ngsi_v2_client.py fails more often, currently no logical reason can be given