### PR TITLE
fix: 69 test clean up uses wrong method to clean entities

### DIFF
--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -566,9 +566,9 @@ class ContextBrokerClient(BaseHttpClient):
         # attributes.
         entities_with_attributes: List[ContextEntity] = []
         for entity in entities:
-            property_names = [key for key in entity.dict() if key not in
+            attribute_names = [key for key in entity.dict() if key not in
                               ContextEntity.__fields__]
-            if len(property_names) > 0:
+            if len(attribute_names) > 0:
                 entities_with_attributes.append(
                     ContextEntity(id=entity.id, type=entity.type))
 

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -555,7 +555,7 @@ class ContextBrokerClient(BaseHttpClient):
         Args:
             entities: List[ContextEntity]: List of entities to be deleted
         Raises:
-            Exception, if
+            Exception, if one of the entities is not in the ContextBroker
         Returns:
             None
         """
@@ -567,7 +567,7 @@ class ContextBrokerClient(BaseHttpClient):
         entities_with_attributes: List[ContextEntity] = []
         for entity in entities:
             attribute_names = [key for key in entity.dict() if key not in
-                              ContextEntity.__fields__]
+                               ContextEntity.__fields__]
             if len(attribute_names) > 0:
                 entities_with_attributes.append(
                     ContextEntity(id=entity.id, type=entity.type))

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -5,8 +5,6 @@ created Oct 08, 2021
 
 @author Thomas Storek
 """
-import time
-
 from requests import RequestException
 from typing import Callable
 from filip.models import FiwareHeader

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -5,6 +5,8 @@ created Oct 08, 2021
 
 @author Thomas Storek
 """
+import time
+
 from requests import RequestException
 from typing import Callable
 from filip.models import FiwareHeader
@@ -32,11 +34,8 @@ def clear_context_broker(url: str, fiware_header: FiwareHeader):
     """
     # create client
     client = ContextBrokerClient(url=url, fiware_header=fiware_header)
-
-    # clear entities
-    entities = client.get_entity_list()
-    if entities:
-        client.update(entities=entities, action_type='delete')
+    # clean entities
+    client.delete_entities(entities=client.get_entity_list())
 
     # clear subscriptions
     for sub in client.get_subscription_list():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ paho-mqtt>=1.5.1
 pandas_datapackage_reader>=0.18.0
 tables>=3.6.1
 python-Levenshtein>=0.12.2
-paho-mqtt
+paho-mqtt==1.5.1
 datamodel_code_generator>=0.11.14

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -78,8 +78,6 @@ class TestAgent(unittest.TestCase):
         self.client.get_group(resource=self.service_group1.resource,
                               apikey=self.service_group1.apikey)
 
-        clear_all(fiware_header=self.fiware_header,
-                  iota_url=settings.IOTA_URL)
 
     def test_device_model(self):
         device = Device(**self.device)
@@ -94,12 +92,6 @@ class TestAgent(unittest.TestCase):
         """
         Test device creation
         """
-        # Clean up Fiware test state, this test can fail if the device was not
-        # correctly removed before
-        clear_all(fiware_header=self.fiware_header,
-                  cb_url=settings.CB_URL,
-                  iota_url=settings.IOTA_URL)
-
         with IoTAClient(
                 url=settings.IOTA_URL,
                 fiware_header=self.fiware_header) as client:
@@ -135,10 +127,6 @@ class TestAgent(unittest.TestCase):
             self.assertEqual(self.fiware_header.service_path,
                              device_res.service_path)
 
-            #cleanup
-            clear_all(fiware_header=self.fiware_header,
-                      cb_url=settings.CB_URL,
-                      iota_url=settings.IOTA_URL)
 
     @clean_test(fiware_service=settings.FIWARE_SERVICE,
                 fiware_servicepath=settings.FIWARE_SERVICEPATH,
@@ -174,11 +162,6 @@ class TestAgent(unittest.TestCase):
                 fiware_header=self.fiware_header) as client:
             logger.info(client.get_entity(entity_id=device.entity_name).json(
                 indent=2))
-
-        #clean up
-        clear_all(fiware_header=self.fiware_header,
-                  cb_url=settings.CB_URL,
-                  iota_url=settings.IOTA_URL)
 
     def tearDown(self) -> None:
         """


### PR DESCRIPTION
Test deletion fixed.

I saw that the use of delete_entity for all entity was much slower than using the batch methode (16s to 6s).

Therefore I implented a methode that can also be used by endusers to efficiently delete entities as batch.
The methode calls update(delete) twice (with controlled logic)

Additionally I removed a few clean-all() class that were redundant, as each test calls it in the tear_down