### PR TITLE
Feat: Patch Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - introduced [CHANGELOG.md](https://github.com/RWTH-EBC/FiLiP/blob/development/CHANGELOG.md) with versions
 - remodeled ngsi-v2 models ([#58,#59,#60](https://github.com/RWTH-EBC/FiLiP/issues/60))
 - improved ContextEntity and Device deleting methods ([#27](https://github.com/RWTH-EBC/FiLiP/issues/28))
+- patch methods for ContextEntity and Device ([#74](https://github.com/RWTH-EBC/FiLiP/issues/74))
 
 #### v0.1.7
 - introduced automatic testing

--- a/examples/orion_example.py
+++ b/examples/orion_example.py
@@ -113,7 +113,7 @@ def update_entity(entity: ContextEntity):
     with ContextBrokerClient(
             fiware_header=FiwareHeader(service='filip',
                                        service_path='/testing')) as cb_client:
-        entity.add_properties({'Space': ContextAttribute(
+        entity.add_attributes({'Space': ContextAttribute(
             type='Number', value=111)})
 
         logger.info("------Updating value of an attribute of an entity------")

--- a/examples/registration_example.py
+++ b/examples/registration_example.py
@@ -50,7 +50,7 @@ windspeed_metadata = NamedMetadata(name="unit",
 windspeed = ContextAttribute(type="Number",
                              value=60)#,
                              #metadata=windspeed_metadata)
-weather_station.add_properties(attrs={"windspeed": windspeed})
+weather_station.add_attributes(attrs={"windspeed": windspeed})
 
 # print complete model
 print("+"*80)

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -10,7 +10,8 @@ from pkg_resources import parse_version
 from pydantic import \
     parse_obj_as, \
     PositiveInt, \
-    PositiveFloat, AnyHttpUrl
+    PositiveFloat, \
+    AnyHttpUrl
 from typing import Any, Dict, List, Union, Optional
 import re
 import requests

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -10,7 +10,7 @@ from pkg_resources import parse_version
 from pydantic import \
     parse_obj_as, \
     PositiveInt, \
-    PositiveFloat
+    PositiveFloat, AnyHttpUrl
 from typing import Any, Dict, List, Union, Optional
 import re
 import requests
@@ -30,6 +30,7 @@ from filip.models.ngsi_v2.context import \
     NamedContextAttribute, \
     Query, \
     Update
+from filip.models.base import DataType
 from filip.models.ngsi_v2.base import AttrsFormat
 from filip.models.ngsi_v2.subscriptions import Subscription
 from filip.models.ngsi_v2.registrations import Registration
@@ -523,7 +524,8 @@ class ContextBrokerClient(BaseHttpClient):
             raise
 
     def delete_entity(self, entity_id: str, entity_type: str,
-                      delete_devices: bool = False) -> None:
+                      delete_devices: bool = False,
+                      iota_url: AnyHttpUrl = settings.IOTA_URL) -> None:
 
         """
         Remove a entity from the context broker. No payload is required
@@ -534,6 +536,7 @@ class ContextBrokerClient(BaseHttpClient):
             entity_type: several entities with the same entity id.
             delete_devices: If True, also delete all devices that reference this
                             entity (entity_id as entity_name)
+            iota_url: URL of the corresponding IotaClient
         Returns:
             None
         """
@@ -554,7 +557,8 @@ class ContextBrokerClient(BaseHttpClient):
 
         if delete_devices:
             from filip.clients.ngsi_v2 import IoTAClient
-            iota_client = IoTAClient(fiware_header=self.fiware_headers)
+            iota_client = IoTAClient(url=iota_url,
+                                     fiware_header=self.fiware_headers)
 
             for device in iota_client.get_device_list(entity=entity_id):
                 if device.entity_type == entity_type:
@@ -1385,6 +1389,137 @@ class ContextBrokerClient(BaseHttpClient):
             msg = "Query operation failed!"
             self.log_error(err=err, msg=msg)
             raise
+
+    def does_entity_exists(self,
+                           entity_id: str,
+                           entity_type: str) -> bool:
+        """
+        Test if an entity with given id and type is present in the CB
+        Args:
+            entity_id: Entity id
+            entity_type: Entity type
+        Returns:
+            bool; True if entity exists
+
+        Raises:
+            RequestException, if any error occurres (e.g: No Connection),
+            except that the entity is not found
+        """
+        try:
+            self.get_entity(entity_id=entity_id, entity_type=entity_type)
+        except requests.RequestException as ex:
+            # couldn't find a better way to extract error code
+            if not str(ex)[0:36] == "404 Client Error: Not Found for url:":
+                raise
+            return False
+        
+        return True
+
+    def patch_entity(self,
+                     entity: ContextEntity,
+                     old_entity: Optional[ContextEntity] = None) -> None:
+        """
+           Takes a given entity and updates the state in the CB to match it.
+           Args:
+               entity: Entity to update
+               old_entity: OPTIONAL, if given only the differences between the
+                           old_entity and entity are updated in the CB.
+                           Other changes made to the entity in CB, can be kept.
+           Returns:
+               None
+        """
+
+        new_entity = entity
+
+        if old_entity is None:
+            # If no old entity_was provided we use the current state to compare
+            # the entity to
+            if self.does_entity_exists(entity_id=new_entity.id,
+                                       entity_type=new_entity.type):
+                old_entity = self.get_entity(entity_id=new_entity.id,
+                                             entity_type=new_entity.type)
+            else:
+                # the entity is new, post and finish
+                self.post_entity(new_entity, update=False)
+                return
+
+        else:
+            # An old_entity was provided
+            # check if the old_entity (still) exists else recall methode
+            # and discard old_entity
+            if not self.does_entity_exists(entity_id=old_entity.id,
+                                           entity_type=old_entity.type):
+                self.patch_entity(new_entity)
+                return
+
+            # if type or id was changed, the old_entity needs to be deleted
+            # and the new_entity created
+            # In this case we will loose the current state of the entity
+            if old_entity.id != new_entity.id or \
+                    old_entity.type != new_entity.type:
+                self.delete_entity(entity_id=old_entity.id,
+                                   entity_type=old_entity.type)
+
+                if not self.does_entity_exists(entity_id=new_entity.id,
+                                               entity_type=new_entity.type):
+                    self.post_entity(entity=new_entity, update=False)
+                    return
+
+        # At this point we know that we need to patch only the attributes of
+        # the entity
+        # Check the differences between the attributes of old and new entity
+        # Delete the removed attributes, create the news,
+        # and update the existing if necessary
+        old_attributes = old_entity.get_properties()
+        old_attributes.extend(old_entity.get_relationships())
+
+        new_attributes = new_entity.get_properties()
+        new_attributes.extend(new_entity.get_relationships())
+
+        # Manage attributes that existed before
+        for old_attr in old_attributes:
+            if not old_attr.type == DataType.COMMAND:
+                # commands do not exist in the ContextEntity and are only
+                # registrations to the corresponding device. Operations as
+                # delete will fail as it does not technically exists
+                corresponding_new_attr = None
+                for new_attr in new_attributes:
+                    if new_attr.name == old_attr.name:
+                        corresponding_new_attr = new_attr
+
+                if corresponding_new_attr is None:
+                    # Attribute no longer exists, delete it
+                    self.delete_entity_attribute(entity_id=new_entity.id,
+                                             entity_type=new_entity.type,
+                                             attr_name=old_attr.name)
+                else:
+                    # Check if attributed changed in any way, if yes update
+                    # else do nothing and keep current state
+                    if not old_attr.__eq__(corresponding_new_attr):
+                        self.update_entity_attribute(entity_id=new_entity.id,
+                                                 entity_type=new_entity.type,
+                                                 attr=corresponding_new_attr)
+
+        # Create new attributes
+        update_entity = ContextEntity(id=entity.id, type=entity.type)
+        update_needed = False
+        for new_attr in new_attributes:
+            if not new_attr.type == DataType.COMMAND:
+                # commands do not exist in the ContextEntity and are only
+                # registrations to the corresponding device. Operations as
+                # delete will fail as it does not technically exists
+                attr_existed = False
+                for old_attr in old_attributes:
+                    if new_attr.name == old_attr.name:
+                        attr_existed = True
+
+                if not attr_existed:
+                    update_needed = True
+                    update_entity.add_attributes([new_attr])
+
+        if update_needed:
+            self.update_entity(update_entity, append=True)
+
 
 
 #    def get_subjects(self, object_entity_name: str, object_entity_type: str, subject_type=None):

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -196,6 +196,7 @@ class IoTAClient(BaseHttpClient):
         by the resource and apikey query parameters. Takes a service group body
         as the payload. The body does not have to be complete: for incomplete
         bodies, just the existing attributes will be updated
+        
         Args:
             service_group (ServiceGroup): Service to update.
             fields: Fields of the service_group to update. If 'None' all allowed

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -233,7 +233,8 @@ class IoTAClient(BaseHttpClient):
 
     def delete_group(self, *, resource: str, apikey: str):
         """
-
+        Deletes a service group in in the IoT-Agent
+        
         Args:
             resource:
             apikey:
@@ -294,7 +295,8 @@ class IoTAClient(BaseHttpClient):
 
     def post_device(self, *, device: Device, update: bool = False) -> None:
         """
-
+        Post a device configuration to the IoT-Agent
+        
         Args:
             device:
             update:
@@ -343,6 +345,7 @@ class IoTAClient(BaseHttpClient):
     def get_device(self, *, device_id: str) -> Device:
         """
         Returns all the information about a particular device.
+        
         Args:
             device_id:
         Raises:
@@ -419,6 +422,7 @@ class IoTAClient(BaseHttpClient):
         """
         Remove a device from the device registry. No payload is required
         or received.
+        
         Args:
             device_id: str, ID of Device
             delete_entity:  False -> Only delete the device entry,
@@ -624,6 +628,7 @@ class IoTAClient(BaseHttpClient):
     def change_loglevel_of_agent(self, level: str):
         """
         Change current loglevel of agent
+        
         Args:
             level:
 

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -547,10 +547,7 @@ class IoTAClient(BaseHttpClient):
 
             for command in device.commands:
                 entity.add_attributes([
-                    NamedContextAttribute(
-                        name=f"{command.name}",
-                        type=DataType.COMMAND
-                    ),
+                    # Command attribute will be registered by the device_update
                     NamedContextAttribute(
                         name=f"{command.name}_info",
                         type=DataType.COMMAND_RESULT
@@ -584,7 +581,6 @@ class IoTAClient(BaseHttpClient):
             with ContextBrokerClient(
                     url=cb_url,
                     fiware_header=self.fiware_headers) as client:
-
                 client.patch_entity(
                     entity=build_context_entity_from_device(device))
 
@@ -599,7 +595,9 @@ class IoTAClient(BaseHttpClient):
         try:
             self.get_device(device_id=device_id)
             return True
-        except requests.RequestException:
+        except requests.RequestException as err:
+            if not err.response.status_code == 404:
+                raise
             return False
 
     # LOG API

--- a/filip/models/ngsi_v2/context.py
+++ b/filip/models/ngsi_v2/context.py
@@ -274,9 +274,15 @@ class ContextEntity(ContextEntityKeyValues):
                          attrs: Union[Dict[str, ContextAttribute],
                                       List[NamedContextAttribute]]) -> None:
         """
-        Update an attribute of an entity
+        Update attributes of an entity. Overwrite the current held value
+        for the attribute with the value contained in the corresponding given
+        attribute
+
         Args:
-            attrs:
+            attrs: List of NamedContextAttributes,
+                   Dict of {attribute_name: ContextAttribute}
+        Raises:
+            NameError, if the attribute does not currently exists in the entity
         Returns:
             None
         """

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -223,7 +223,7 @@ class TestContextBroker(unittest.TestCase):
             client.update_entity(entity=res_entity)
             self.assertEqual(client.get_entity(entity_id=self.entity.id),
                              res_entity)
-            res_entity.add_properties({'pressure': ContextAttribute(
+            res_entity.add_attributes({'pressure': ContextAttribute(
                 type='Number', value=1050)})
             client.update_entity(entity=res_entity)
             self.assertEqual(client.get_entity(entity_id=self.entity.id),
@@ -255,7 +255,7 @@ class TestContextBroker(unittest.TestCase):
             attr_dict = NamedContextAttribute(name='attr_dict',
                                               type='StructuredValue',
                                               value={'key': 'value'})
-            entity.add_properties([attr_txt,
+            entity.add_attributes([attr_txt,
                                    attr_bool,
                                    attr_float,
                                    attr_list,

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -8,7 +8,7 @@ import requests
 
 from uuid import uuid4
 
-from filip.models.base import FiwareHeader
+from filip.models.base import FiwareHeader, DataType
 from filip.clients.ngsi_v2 import \
     ContextBrokerClient, \
     IoTAClient
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestAgent(unittest.TestCase):
+
     def setUp(self) -> None:
         self.fiware_header = FiwareHeader(
             service=settings.FIWARE_SERVICE,
@@ -177,15 +178,16 @@ class TestAgent(unittest.TestCase):
                         entity_name=entity_id,
                         entity_type='Thing2',
                         protocol='IoTA-JSON',
-                        transport='MQTT',
+                        transport='HTTP',
                         apikey='filip-iot-test-device')
 
-        cb_client = ContextBrokerClient(fiware_header=self.fiware_header)
+        cb_client = ContextBrokerClient(url=settings.CB_URL,
+                                        fiware_header=self.fiware_header)
 
         # Test 1: Only delete device
         # delete without optional parameter -> entity needs to continue existing
         self.client.post_device(device=device)
-        self.client.delete_device(device_id=device_id)
+        self.client.delete_device(device_id=device_id, cb_url=settings.CB_URL)
         self.assertTrue(
             len(cb_client.get_entity_list(entity_ids=[entity_id])) == 1)
         cb_client.delete_entity(entity_id=entity_id, entity_type='Thing2')
@@ -194,6 +196,7 @@ class TestAgent(unittest.TestCase):
         # delete with optional parameter -> entity needs to be deleted
         self.client.post_device(device=device)
         self.client.delete_device(device_id=device_id,
+                                  cb_url=settings.CB_URL,
                                   delete_entity=True)
         self.assertTrue(
             len(cb_client.get_entity_list(entity_ids=[entity_id])) == 0)
@@ -225,15 +228,147 @@ class TestAgent(unittest.TestCase):
         device2.device_id = "device_id2"
         self.client.post_device(device=device2)
         cb_client.delete_entity(entity_id=entity_id, delete_devices=True,
-                                entity_type='Thing2')
+                                entity_type='Thing2',
+                                iota_url=settings.IOTA_JSON_URL)
         self.assertEqual(len(self.client.get_device_list()), 0)
 
+    def test_update_device(self):
+        """
+        Test the methode: update_device of the iota client
+        """
+
+        device = Device(**self.device)
+        device.endpoint = "http://test.com"
+        device.transport = "MQTT"
+
+        device.add_attribute(DeviceAttribute(
+            name="Att1", object_id="o1", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat1", value="test", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat2", value="test", type=DataType.STRUCTUREDVALUE))
+        device.add_command(DeviceCommand(name="Com1"))
+
+        # use update_device to post
+        self.client.update_device(device=device, add=True)
+
+        cb_client = ContextBrokerClient(url=settings.CB_URL,
+                                        fiware_header=self.fiware_header)
+
+        # test if attributes exists correctly
+        live_entity = cb_client.get_entity(entity_id=device.entity_name)
+        live_entity.get_attribute("Att1")
+        live_entity.get_attribute("Com1")
+        live_entity.get_attribute("Com1_info")
+        live_entity.get_attribute("Com1_status")
+        self.assertEqual(live_entity.get_attribute("Stat1").value, "test")
+
+        # change device attributes and update
+        device.get_attribute("Stat1").value = "new_test"
+        device.delete_attribute(device.get_attribute("Stat2"))
+        device.delete_attribute(device.get_attribute("Att1"))
+        device.delete_attribute(device.get_attribute("Com1"))
+        device.add_attribute(DeviceAttribute(
+            name="Att2", object_id="o1", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat3", value="test3", type=DataType.STRUCTUREDVALUE))
+        device.add_command(DeviceCommand(name="Com2"))
+
+        # device.endpoint = "http://localhost:8080"
+        self.client.update_device(device=device)
+
+        # test if update does what it should, for the device. It does not
+        # change the entity completely:
+
+        live_device = self.client.get_device(device_id=device.device_id)
+
+        with self.assertRaises(KeyError):
+            live_device.get_attribute("Att1")
+        with self.assertRaises(KeyError):
+            live_device.get_attribute("Com1_info")
+        with self.assertRaises(KeyError):
+            live_device.get_attribute("Stat2")
+        self.assertEqual(live_device.get_attribute("Stat1").value, "new_test")
+        live_device.get_attribute("Stat3")
+        live_device.get_command("Com2")
+        live_device.get_attribute("Att2")
+
         cb_client.close()
-        
-        #clean up
-        clear_all(fiware_header=self.fiware_header,
-                  cb_url=settings.CB_URL,
-                  iota_url=settings.IOTA_JSON_URL)
+
+    def test_patch_device(self):
+        """
+            Test the methode: patch_device of the iota client
+        """
+
+        device = Device(**self.device)
+        device.endpoint = "http://test.com"
+        device.transport = "MQTT"
+
+        device.add_attribute(DeviceAttribute(
+            name="Att1", object_id="o1", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat1", value="test", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat2", value="test", type=DataType.STRUCTUREDVALUE))
+        device.add_command(DeviceCommand(name="Com1"))
+
+        # use patch_device to post
+        self.client.patch_device(device=device)
+
+        cb_client = ContextBrokerClient(url=settings.CB_URL,
+                                        fiware_header=self.fiware_header)
+
+        # test if attributes exists correctly
+        live_entity = cb_client.get_entity(entity_id=device.entity_name)
+        live_entity.get_attribute("Att1")
+        live_entity.get_attribute("Com1")
+        live_entity.get_attribute("Com1_info")
+        live_entity.get_attribute("Com1_status")
+        self.assertEqual(live_entity.get_attribute("Stat1").value, "test")
+
+        # change device attributes and update
+        device.get_attribute("Stat1").value = "new_test"
+        device.delete_attribute(device.get_attribute("Stat2"))
+        device.delete_attribute(device.get_attribute("Att1"))
+        device.delete_attribute(device.get_attribute("Com1"))
+        device.add_attribute(DeviceAttribute(
+            name="Att2", object_id="o1", type=DataType.STRUCTUREDVALUE))
+        device.add_attribute(StaticDeviceAttribute(
+            name="Stat3", value="test3", type=DataType.STRUCTUREDVALUE))
+        device.add_command(DeviceCommand(name="Com2"))
+
+        self.client.patch_device(device=device, cb_url=settings.CB_URL)
+
+        # test if update does what it should, for the device. It does not
+        # change the entity completely:
+        live_entity = cb_client.get_entity(entity_id=device.entity_name)
+        with self.assertRaises(KeyError):
+            live_entity.get_attribute("Att1")
+        with self.assertRaises(KeyError):
+            live_entity.get_attribute("Com1_info")
+        with self.assertRaises(KeyError):
+            live_entity.get_attribute("Stat2")
+        self.assertEqual(live_entity.get_attribute("Stat1").value, "new_test")
+        live_entity.get_attribute("Stat3")
+        live_entity.get_attribute("Com2_info")
+        live_entity.get_attribute("Att2")
+
+        # test update where device information were changed
+        device_settings = {"endpoint": "http://localhost:7071",
+                           "device_id": "new_id",
+                           "entity_name": "new_name",
+                           "entity_type": "new_type",
+                           "timestamp": False,
+                           "apikey": "zuiop",
+                           "protocol": "HTTP",
+                           "transport": "HTTP"}
+
+        for key, value in device_settings.items():
+            device.__setattr__(key, value)
+            self.client.patch_device(device=device)
+            live_device = self.client.get_device(device_id=device.device_id)
+            self.assertEqual(live_device.__getattribute__(key), value)
+            cb_client.close()
 
     def tearDown(self) -> None:
         """

--- a/tests/models/test_ngsi_v2_context.py
+++ b/tests/models/test_ngsi_v2_context.py
@@ -98,7 +98,7 @@ class TestContextModels(unittest.TestCase):
             exclude={'name', 'metadata'}, exclude_unset=True)})
 
         new_attr = {'new_attr': ContextAttribute(type='Number', value=25)}
-        entity.add_properties(new_attr)
+        entity.add_attributes(new_attr)
 
         generated_model = create_context_entity_model(data=self.entity_data)
         entity = generated_model(**self.entity_data)


### PR DESCRIPTION
I added the Patch device method and the tests as described in issue 74.
I discovered that Patch Entity and the context model changes were not yet live on development and only local in #30. 

I therefore bundled here all these changes to be reviewed together.

The made changes can be summarized as:
- Patch Methods (Device and Entity)
- ContextEntity Remodel (to make attribute interface more clear to the user)
- Helper functions (does entity/device exists ?)
- Test functions to test new and a few old uncovered methods
- Change of comments to make functionality more clear