### PR TITLE
Added Semantic instance metadata

### DIFF
--- a/examples/semantics/semantics_model_example.py
+++ b/examples/semantics/semantics_model_example.py
@@ -344,6 +344,16 @@ if __name__ == '__main__':
     # If a required field of the new property is already existing an error is
     # raised
 
+    # ## 3.3 Metadata
+    #
+    # Each instance has the special attribute "metadata".
+    # Here the user can save information that can help him identify the
+    # instance. He can give the instance a name, and leave a comment
+
+    my_floor.metadata.name = "First Basement"
+    my_floor.metadata.comment = "The first basement is directly below the " \
+                                "ground"
+
     # # 4 State Management
     #
     # We now have seen how the models can be instantiated, filled with

--- a/filip/semantics/semantics_manager.py
+++ b/filip/semantics/semantics_manager.py
@@ -17,7 +17,8 @@ from filip.models import FiwareHeader
 from filip.semantics.semantics_models import \
     InstanceIdentifier, SemanticClass, InstanceHeader, Datatype, DataField, \
     RelationField, SemanticIndividual, SemanticDeviceClass, CommandField, \
-    Command, DeviceAttributeField, DeviceAttribute, DeviceSettings
+    Command, DeviceAttributeField, DeviceAttribute, DeviceSettings, \
+    SemanticMetadata
 
 logger = logging.getLogger('semantics')
 
@@ -324,6 +325,11 @@ class SemanticsManager(BaseModel):
                 loaded_class.add_reference(
                     InstanceIdentifier.parse_raw(identifier_str.replace(
                         "---", ".")), prop)
+
+        # load metadata
+        metadata_dict = entity.get_attribute("metadata").value
+        loaded_class.metadata.name = metadata_dict['name']
+        loaded_class.metadata.comment = metadata_dict['comment']
 
         # load device_settings into instance, if instance is a device
         if isinstance(loaded_class, SemanticDeviceClass):

--- a/filip/semantics/semantics_models.py
+++ b/filip/semantics/semantics_models.py
@@ -1095,6 +1095,23 @@ class InstanceState(BaseModel):
     state: Optional[ContextEntity]
 
 
+class SemanticMetadata(BaseModel):
+    """
+    Meta information about an semantic instance.
+    A name and comment that can be used by the user to better identify the
+    instance
+    """
+    name: str = pyd.Field(default="",
+                          description="Optional user-given name for the "
+                                      "instance")
+    comment: str = pyd.Field(default="",
+                             description="Optional user-given comment for "
+                                         "the instance")
+
+    class Config:
+        validate_assignment = True
+
+
 class SemanticClass(BaseModel):
     """
     A class representing a vocabulary/ontology class.
@@ -1132,6 +1149,12 @@ class SemanticClass(BaseModel):
         description="Pointer to the governing semantic_manager, "
                     "vague type to prevent forward ref problems. "
                     "But it will be of type 'SemanticsManager' in runtime")
+
+    metadata: SemanticMetadata = pyd.Field(
+        default=SemanticMetadata(),
+        description="Meta information about the instance. A name and comment "
+                    "that can be used by the user to better identify the "
+                    "instance")
 
     def add_reference(self, identifier: InstanceIdentifier, relation_name: str):
         """
@@ -1433,6 +1456,13 @@ class SemanticClass(BaseModel):
                 value=reference_str_dict
             )
         ])
+        entity.add_attributes([
+            NamedContextAttribute(
+                name="metadata",
+                type=DataType.STRUCTUREDVALUE,
+                value=self.metadata.dict()
+            )
+        ])
 
         return entity
 
@@ -1635,20 +1665,23 @@ class SemanticDeviceClass(SemanticClass):
                 name="referencedBy",
                 type=DataType.STRUCTUREDVALUE,
                 value=reference_str_dict,
-                entity_name=None,
-                entity_type=None,
             )
         )
-
+        device.add_attribute(
+            iot.StaticDeviceAttribute(
+                name="metadata",
+                type=DataType.STRUCTUREDVALUE,
+                value=self.metadata.dict()
+            )
+        )
         device.add_attribute(
             iot.StaticDeviceAttribute(
                 name="deviceSettings",
                 type=DataType.STRUCTUREDVALUE,
                 value=self.device_settings.dict(),
-                entity_name=None,
-                entity_type=None,
             )
         )
+
 
         return device
 

--- a/filip/semantics/vocabulary_configurator.py
+++ b/filip/semantics/vocabulary_configurator.py
@@ -31,7 +31,8 @@ from filip.semantics.vocabulary import \
 label_blacklist = list(keyword.kwlist)
 label_blacklist.extend(["referencedBy", "deviceSettings"])
 label_blacklist.extend(["references", "device_settings", "header",
-                        "old_state", "", "semantic_manager", "delete"])
+                        "old_state", "", "semantic_manager", "delete",
+                        "metadata"])
 label_blacklist.extend(["id", "type", "class"])
 label_blacklist.extend(["str", "int", "float", "complex", "list", "tuple",
                         "range", "dict", "list", "set", "frozenset", "bool",

--- a/tests/semantics/test_semantics_models.py
+++ b/tests/semantics/test_semantics_models.py
@@ -850,15 +850,7 @@ class TestSemanticsModels(unittest.TestCase):
                     self.assertEqual(attr.value, ['1'])
 
     def test__20_metadata(self):
-        from models2 import Class3, semantic_manager
-
-        test_header = InstanceHeader(
-            cb_url=settings.CB_URL,
-            iota_url=settings.IOTA_JSON_URL,
-            service=settings.FIWARE_SERVICE,
-            service_path=settings.FIWARE_SERVICEPATH
-        )
-        semantic_manager.set_default_header(test_header)
+        from tests.semantics.models2 import Class3, semantic_manager
 
         # create and save
         inst = Class3(id="1")
@@ -873,7 +865,7 @@ class TestSemanticsModels(unittest.TestCase):
         self.clear_registry()
 
         # load and check
-        inst = Class3(id="1", header=test_header)
+        inst = Class3(id="1")
         print(inst)
         self.assertEqual(inst.metadata.name, "TestName")
         self.assertEqual(inst.metadata.comment, "TestComment")

--- a/tests/semantics/test_semantics_models.py
+++ b/tests/semantics/test_semantics_models.py
@@ -765,7 +765,6 @@ class TestSemanticsModels(unittest.TestCase):
         from tests.semantics.models2 import Class3, semantic_manager, \
             customDataType4
 
-
         # setup state
         inst_1 = Class3(id="3")
 
@@ -849,6 +848,35 @@ class TestSemanticsModels(unittest.TestCase):
             for attr in device_entity.static_attributes:
                 if attr.name == "dataProp1":
                     self.assertEqual(attr.value, ['1'])
+
+    def test__20_metadata(self):
+        from models2 import Class3, semantic_manager
+
+        test_header = InstanceHeader(
+            cb_url=settings.CB_URL,
+            iota_url=settings.IOTA_JSON_URL,
+            service=settings.FIWARE_SERVICE,
+            service_path=settings.FIWARE_SERVICEPATH
+        )
+        semantic_manager.set_default_header(test_header)
+
+        # create and save
+        inst = Class3(id="1")
+
+        inst.metadata.name = "TestName"
+        inst.metadata.comment = "TestComment"
+        inst.device_settings.endpoint = "http://Idontcare"
+        inst.device_settings.transport = TransportProtocol.HTTP
+        semantic_manager.save_state()
+
+        # clear local info
+        self.clear_registry()
+
+        # load and check
+        inst = Class3(id="1", header=test_header)
+        print(inst)
+        self.assertEqual(inst.metadata.name, "TestName")
+        self.assertEqual(inst.metadata.comment, "TestComment")
 
     def tearDown(self) -> None:
         """


### PR DESCRIPTION
Added feature, tests, documentation.

I created the metadata attribute in the SemanticClass. 
This name works neatly as a ContextEntity itself does not possess metadata, and these information can be considered metadata.
This form adds minimal difference, and is easily extendable if in the future more information should be kept as metadata.