### PR TITLE
Better semantic load function

### DIFF
--- a/filip/semantics/semantics_models.py
+++ b/filip/semantics/semantics_models.py
@@ -22,7 +22,7 @@ from filip.semantics.vocabulary_configurator import label_blacklist, \
     label_char_whitelist
 
 if TYPE_CHECKING:
-    from filip.semantics.semantic_manager import SemanticManager
+    from filip.semantics.semantics_manager import SemanticsManager
 
 
 class InstanceHeader(FiwareHeader):


### PR DESCRIPTION
I implemented the parameters from get_entity_list that were logical to be included into load_instances_from_fiware().
Now semantics offers more querying flexibility.

I left out:
 
- all metadata querries, as semantics currently does not work with metadata.
- All responseformats as always a whole semantic instance needs to be loaded
- the geolocation querries

+ small import fix