### PR TITLE
Improved Test Cleanup

### DIFF
--- a/filip/clients/ngsi_v2/quantumleap.py
+++ b/filip/clients/ngsi_v2/quantumleap.py
@@ -258,7 +258,7 @@ class QuantumLeapClient(BaseHttpClient):
                 self.logger.info("Entity id '%s' successfully deleted!",
                                  entity_id)
                 return entity_id
-            time.sleep(counter/5)
+            time.sleep(counter*5)
             counter += 1
 
         msg = f"Could not delete QL entity of id {entity_id}"

--- a/filip/clients/ngsi_v2/quantumleap.py
+++ b/filip/clients/ngsi_v2/quantumleap.py
@@ -244,16 +244,6 @@ class QuantumLeapClient(BaseHttpClient):
         else:
             params = {}
 
-        # Test if entity with given parameters exists, if not throw an error
-        try:
-            self.get_entity_by_id(entity_id=entity_id,
-                                  entity_type=entity_type)
-        except requests.exceptions.RequestException as err:
-            msg = f"Could not delete entity of id {entity_id}, it does not " \
-                  f"exist"
-            self.log_error(err=err, msg=msg)
-            raise
-
         # The deletion does not always resolves in a success even if an ok is
         # returned.
         # Try to delete multiple times with incrementing waits.

--- a/filip/clients/ngsi_v2/quantumleap.py
+++ b/filip/clients/ngsi_v2/quantumleap.py
@@ -248,6 +248,8 @@ class QuantumLeapClient(BaseHttpClient):
         # returned.
         # Try to delete multiple times with incrementing waits.
         # If the entity is no longer found the methode returns with a success
+        # If the deletion attempt fails after the 10th try, raise an
+        # Exception: it could not be deleted
         counter = 0
         while counter < 10:
             self.delete(url=url, headers=headers, params=params)

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -128,15 +128,8 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
         while len(entities) > 0 and counter < 10:
             print(f"-----{counter}----------{len(client.get_entities())}")
             print(len(client.get_entities()))
-            for entity in entities:
-                try:
-                    client.delete_entity(entity_id=entity.entityId,
-                                         entity_type=entity.entityType)
-                except RequestException as err:
-                    handle_emtpy_db_exception(err)
-            entities = client.get_entities()
             counter += 1
-            time.sleep(counter)
+            time.sleep(counter/10)
     except RequestException as err:
         handle_emtpy_db_exception(err)
 

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -103,19 +103,19 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     client = QuantumLeapClient(url=url, fiware_header=fiware_header)
 
     # clear data
-    entities = []
-    try:
-        entities = client.get_entities()
-    except RequestException as err:
-        handle_emtpy_db_exception(err)
-
-    # will be executed for all found entities
-    for entity in entities:
-        try:
-            client.delete_entity(entity_id=entity.entityId,
-                                 entity_type=entity.entityType)
-        except RequestException as err:
-            handle_emtpy_db_exception(err)
+    # entities = []
+    # try:
+    #     entities = client.get_entities()
+    # except RequestException as err:
+    #     handle_emtpy_db_exception(err)
+    #
+    # # will be executed for all found entities
+    # for entity in entities:
+    #     try:
+    #         client.delete_entity(entity_id=entity.entityId,
+    #                              entity_type=entity.entityType)
+    #     except RequestException as err:
+    #         handle_emtpy_db_exception(err)
 
     # test if all entities are deleted. If the client is not empty the assert
     # will fail. Else the request will throw an error, the error handler
@@ -124,12 +124,23 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
 
     counter = 0
     try:
-        print(f"ENTITIES: {client.get_entities()}")
-        print(len(client.get_entities()))
-        time.sleep(2)
-        assert len(client.get_entities()) == 0
+        entities = client.get_entities()
+        while len(entities) > 0 and counter < 10:
+            print("---------------------------------")
+            print(len(client.get_entities()))
+            for entity in entities:
+                try:
+                    client.delete_entity(entity_id=entity.entityId,
+                                         entity_type=entity.entityType)
+                except RequestException as err:
+                    handle_emtpy_db_exception(err)
+            entities = client.get_entities()
+            counter += 1
+            time.sleep(counter/10)
     except RequestException as err:
         handle_emtpy_db_exception(err)
+
+    assert len(client.get_entities()) == 0
 
 
 def clear_all(*,

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -126,8 +126,6 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     try:
         entities = client.get_entities()
         while len(entities) > 0 and counter < 10:
-            print(f"-----{counter}----------{len(client.get_entities())}")
-            print(len(client.get_entities()))
             for entity in entities:
                 try:
                     client.delete_entity(entity_id=entity.entityId,
@@ -136,13 +134,12 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
                     handle_emtpy_db_exception(err)
             entities = client.get_entities()
             counter += 1
-            time.sleep(counter/10)
+            time.sleep(counter)
     except RequestException as err:
         handle_emtpy_db_exception(err)
 
-
     try:
-        if len(client.get_entities()) >0:
+        if len(client.get_entities()) > 0:
             assert False, "Not correctly deleted"
     except RequestException as err:
         handle_emtpy_db_exception(err)

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -121,9 +121,12 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     # will fail. Else the request will throw an error, the error handler
     # checks if the error, is due to an empty list else it will raise an
     # error itself
+
+    counter = 0
     try:
         print(f"ENTITIES: {client.get_entities()}")
         print(len(client.get_entities()))
+        time.sleep(2)
         assert len(client.get_entities()) == 0
     except RequestException as err:
         handle_emtpy_db_exception(err)

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -126,6 +126,8 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     try:
         entities = client.get_entities()
         while len(entities) > 0 and counter < 10:
+            print(f"-----{counter}----------{len(client.get_entities())}")
+            print(len(client.get_entities()))
             for entity in entities:
                 try:
                     client.delete_entity(entity_id=entity.entityId,

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -142,7 +142,8 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
 
 
     try:
-        assert len(client.get_entities()) == 0
+        if len(client.get_entities()) >0:
+            assert False, "Not correctly deleted"
     except RequestException as err:
         handle_emtpy_db_exception(err)
 

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -122,7 +122,8 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     # checks if the error, is due to an empty list else it will raise an
     # error itself
     try:
-        print(client.get_entities())
+        print(f"ENTITIES: {client.get_entities()}")
+        print(len(client.get_entities()))
         assert len(client.get_entities()) == 0
     except RequestException as err:
         handle_emtpy_db_exception(err)

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -111,27 +111,35 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
 
     # will be executed for all found entities
     for entity in entities:
-        try:
-            client.delete_entity(entity_id=entity.entityId,
-                                 entity_type=entity.entityType)
-        except RequestException as err:
-            handle_emtpy_db_exception(err)
+        # try:
+        client.delete_entity(entity_id=entity.entityId,
+                             entity_type=entity.entityType)
+        # except RequestException as err:
+        #     handle_emtpy_db_exception(err)
+
 
     # test if all entities are deleted. If the client is not empty the assert
     # will fail. Else the request will throw an error, the error handler
     # checks if the error, is due to an empty list else it will raise an
     # error itself
-
-    counter = 0
-    try:
-        entities = client.get_entities()
-        while len(entities) > 0 and counter < 10:
-            print(f"-----{counter}----------{len(client.get_entities())}")
-            print(len(client.get_entities()))
-            counter += 1
-            time.sleep(counter/10)
-    except RequestException as err:
-        handle_emtpy_db_exception(err)
+    #
+    # counter = 0
+    # try:
+    #     entities = client.get_entities()
+    #     while len(entities) > 0 and counter < 10:
+    #         print(f"-----{counter}----------{len(client.get_entities())}")
+    #         print(len(client.get_entities()))
+    #         for entity in entities:
+    #             try:
+    #                 client.delete_entity(entity_id=entity.entityId,
+    #                                      entity_type=entity.entityType)
+    #             except RequestException as err:
+    #                 handle_emtpy_db_exception(err)
+    #         entities = client.get_entities()
+    #         counter += 1
+    #         time.sleep(counter)
+    # except RequestException as err:
+    #     handle_emtpy_db_exception(err)
 
     try:
         if len(client.get_entities()) > 0:

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -126,7 +126,7 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     try:
         entities = client.get_entities()
         while len(entities) > 0 and counter < 10:
-            print("---------------------------------")
+            print(f"-----{counter}----------{len(client.get_entities())}")
             print(len(client.get_entities()))
             for entity in entities:
                 try:
@@ -140,7 +140,11 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     except RequestException as err:
         handle_emtpy_db_exception(err)
 
-    assert len(client.get_entities()) == 0
+
+    try:
+        assert len(client.get_entities()) == 0
+    except RequestException as err:
+        handle_emtpy_db_exception(err)
 
 
 def clear_all(*,

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -118,6 +118,8 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
             handle_emtpy_db_exception(err)
 
     try:
+        if not len(client.get_entities()) == 0:
+            time.sleep(0.5)
         assert len(client.get_entities()) == 0
     except RequestException as err:
         handle_emtpy_db_exception(err)

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -117,12 +117,16 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
         except RequestException as err:
             handle_emtpy_db_exception(err)
 
+    # test if all entities are deleted. If the client is not empty the assert
+    # will fail. Else the request will throw an error, the error handler
+    # checks if the error, is due to an empty list else it will raise an
+    # error itself
     try:
-        if not len(client.get_entities()) == 0:
-            time.sleep(0.5)
+        print(client.get_entities())
         assert len(client.get_entities()) == 0
     except RequestException as err:
         handle_emtpy_db_exception(err)
+
 
 def clear_all(*,
               fiware_header: FiwareHeader,

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -103,19 +103,19 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
     client = QuantumLeapClient(url=url, fiware_header=fiware_header)
 
     # clear data
-    # entities = []
-    # try:
-    #     entities = client.get_entities()
-    # except RequestException as err:
-    #     handle_emtpy_db_exception(err)
-    #
-    # # will be executed for all found entities
-    # for entity in entities:
-    #     try:
-    #         client.delete_entity(entity_id=entity.entityId,
-    #                              entity_type=entity.entityType)
-    #     except RequestException as err:
-    #         handle_emtpy_db_exception(err)
+    entities = []
+    try:
+        entities = client.get_entities()
+    except RequestException as err:
+        handle_emtpy_db_exception(err)
+
+    # will be executed for all found entities
+    for entity in entities:
+        try:
+            client.delete_entity(entity_id=entity.entityId,
+                                 entity_type=entity.entityType)
+        except RequestException as err:
+            handle_emtpy_db_exception(err)
 
     # test if all entities are deleted. If the client is not empty the assert
     # will fail. Else the request will throw an error, the error handler

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -111,36 +111,14 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
 
     # will be executed for all found entities
     for entity in entities:
-        # try:
         client.delete_entity(entity_id=entity.entityId,
                              entity_type=entity.entityType)
-        # except RequestException as err:
-        #     handle_emtpy_db_exception(err)
 
-
-    # test if all entities are deleted. If the client is not empty the assert
-    # will fail. Else the request will throw an error, the error handler
-    # checks if the error, is due to an empty list else it will raise an
-    # error itself
-    #
-    # counter = 0
-    # try:
-    #     entities = client.get_entities()
-    #     while len(entities) > 0 and counter < 10:
-    #         print(f"-----{counter}----------{len(client.get_entities())}")
-    #         print(len(client.get_entities()))
-    #         for entity in entities:
-    #             try:
-    #                 client.delete_entity(entity_id=entity.entityId,
-    #                                      entity_type=entity.entityType)
-    #             except RequestException as err:
-    #                 handle_emtpy_db_exception(err)
-    #         entities = client.get_entities()
-    #         counter += 1
-    #         time.sleep(counter)
-    # except RequestException as err:
-    #     handle_emtpy_db_exception(err)
-
+    # test if all entities are deleted.
+    # If the client is not empty the assert will fail.
+    # Else the request will throw an error, the error handler
+    # checks if the error is because no entries exist -> Success
+    # else it will raise an error itself
     try:
         if len(client.get_entities()) > 0:
             assert False, "Not correctly deleted"

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -40,12 +40,13 @@ def clear_context_broker(url: str, fiware_header: FiwareHeader):
     # clear subscriptions
     for sub in client.get_subscription_list():
         client.delete_subscription(subscription_id=sub.id)
+    assert len(client.get_subscription_list()) == 0
 
     # clear registrations
     for reg in client.get_registration_list():
         client.delete_registration(registration_id=reg.id)
+    assert len(client.get_registration_list()) == 0
 
-    time.sleep(0.5)
 
 def clear_iot_agent(url: str, fiware_header: FiwareHeader):
     """
@@ -65,13 +66,13 @@ def clear_iot_agent(url: str, fiware_header: FiwareHeader):
     # clear registrations
     for device in client.get_device_list():
         client.delete_device(device_id=device.device_id)
+    assert len(client.get_device_list()) == 0
 
     # clear groups
     for group in client.get_group_list():
         client.delete_group(resource=group.resource,
                             apikey=group.apikey)
-
-    time.sleep(0.5)
+    assert len(client.get_group_list()) == 0
 
 
 def clear_quantumleap(url: str, fiware_header: FiwareHeader):
@@ -116,7 +117,10 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
         except RequestException as err:
             handle_emtpy_db_exception(err)
 
-    time.sleep(0.5)
+    try:
+        assert len(client.get_entities()) == 0
+    except RequestException as err:
+        handle_emtpy_db_exception(err)
 
 def clear_all(*,
               fiware_header: FiwareHeader,

--- a/filip/utils/cleanup.py
+++ b/filip/utils/cleanup.py
@@ -114,17 +114,6 @@ def clear_quantumleap(url: str, fiware_header: FiwareHeader):
         client.delete_entity(entity_id=entity.entityId,
                              entity_type=entity.entityType)
 
-    # test if all entities are deleted.
-    # If the client is not empty the assert will fail.
-    # Else the request will throw an error, the error handler
-    # checks if the error is because no entries exist -> Success
-    # else it will raise an error itself
-    try:
-        if len(client.get_entities()) > 0:
-            assert False, "Not correctly deleted"
-    except RequestException as err:
-        handle_emtpy_db_exception(err)
-
 
 def clear_all(*,
               fiware_header: FiwareHeader,


### PR DESCRIPTION
I removed the unneeded sleeps from the clean-up function, and ensured that the delete works as intended.

For the QL, i added a limited counter loop in the delete function, as tests showed that multiple tries were needed until the deletion was completed. 

Currently there seems to be a small chance 1/10 that even after all deletes were detected as successful, the QL still finds entries. I currently do not know the cause, but as it does not impact any tests, I "ignored" it now for the moment