### PR TITLE
Fix: Filtered Commands

### DIFF
--- a/filip/models/ngsi_v2/context.py
+++ b/filip/models/ngsi_v2/context.py
@@ -2,7 +2,7 @@
 NGSIv2 models for context broker interaction
 """
 import json
-from typing import Any, Type, List, Dict, Union, Optional, Set
+from typing import Any, Type, List, Dict, Union, Optional, Set, Tuple
 from aenum import Enum
 from pydantic import \
     BaseModel, \
@@ -458,8 +458,8 @@ class ContextEntity(ContextEntityKeyValues):
                     for c in commands}
 
     def get_command_triple(self, command_attribute_name: str)\
-            -> (NamedContextAttribute, NamedContextAttribute,
-                NamedContextAttribute):
+            -> Tuple[NamedContextAttribute, NamedContextAttribute,
+                     NamedContextAttribute]:
         """
         Returns for a given command attribute name all three corresponding
         attributes as triple


### PR DESCRIPTION
Filtered commands from get_properties according to the new command logic:

A command is not defined by the DataType.Command but if it has the two auto-generated siblings: _info and _status