### PR TITLE
143 unrelevant devices get deleted by cb delete entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v0.2.4
+- fixed coupled delete of devices and entities ([#143](https://github.com/RWTH-EBC/FiLiP/issues/143))
+
 #### v0.2.3
 - Add images to tutorials ([#139](https://github.com/RWTH-EBC/FiLiP/issues/139))
 

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -553,7 +553,7 @@ class ContextBrokerClient(BaseHttpClient):
             iota_client = IoTAClient(url=iota_url,
                                      fiware_header=self.fiware_headers)
 
-            for device in iota_client.get_device_list(entity=entity_id):
+            for device in iota_client.get_device_list(entity_names=[entity_id]):
                 if device.entity_type == entity_type:
                     iota_client.delete_device(device_id=device.device_id)
 

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -8,7 +8,7 @@ from pydantic import parse_obj_as, AnyHttpUrl
 from filip.config import settings
 from filip.clients.base_http_client import BaseHttpClient
 from filip.models.base import FiwareHeader
-from filip.models.ngsi_v2.iot import Device, ServiceGroup, PayloadProtocol
+from filip.models.ngsi_v2.iot import Device, ServiceGroup
 from filip.utils.iot import filter_device_list
 
 
@@ -537,7 +537,7 @@ class IoTAClient(BaseHttpClient):
                          "timestamp", "apikey", "endpoint",
                          "protocol", "transport",
                          "expressionLanguage"}
-        import json
+
         live_settings = live_device.dict(include=settings_dict)
         new_settings = device.dict(include=settings_dict)
 

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -480,9 +480,9 @@ class IoTAClient(BaseHttpClient):
             # Only delete the entity if
             devices = self.get_device_list(entity_names=[device.entity_name])
             if len(devices) > 0 and not force_entity_deletion:
-                raise Exception(f"The Corresponding Entity to the device "
-                                f"{device_id} is linked to multiple devices, "
-                                "it was not deleted")
+                raise Exception(f"The corresponding entity to the device "
+                                f"{device_id} was not deleted because it is "
+                                f"linked to multiple devices. ")
             else:
                 try:
                     from filip.clients.ngsi_v2 import ContextBrokerClient

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -9,6 +9,7 @@ from filip.config import settings
 from filip.clients.base_http_client import BaseHttpClient
 from filip.models.base import FiwareHeader
 from filip.models.ngsi_v2.iot import Device, ServiceGroup, PayloadProtocol
+from filip.utils.iot import filter_device_list
 
 
 class IoTAClient(BaseHttpClient):
@@ -342,33 +343,12 @@ class IoTAClient(BaseHttpClient):
                 devices = parse_obj_as(List[Device], res.json()['devices'])
                 if entity:
                     # filter with entity id
-                    devices = self.filter_device_list(devices, entity_name=[entity])
+                    devices = filter_device_list(devices, entity_name=[entity])
                 return devices
             res.raise_for_status()
         except requests.RequestException as err:
             self.log_error(err=err, msg=None)
             raise
-
-    @staticmethod
-    def filter_device_list(devices: List[Device],
-                           entity_name: List[str] = None,
-                           entity_type: List[str] = None) -> List[Device]:
-        """
-        Filter the given device list based on conditions
-
-        Args:
-            devices: device list that need to be filtered
-            entity_name: A list of entity_name (e.g. entity_id) as filter condition
-            entity_type: A list of entity_type as filter condition
-
-        Returns:
-
-        """
-        if entity_name:
-            devices = [device for device in devices if device.entity_name in entity_name]
-        if entity_type:
-            devices = [device for device in devices if device.entity_type in entity_type]
-        return devices
 
     def get_device(self, *, device_id: str) -> Device:
         """

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -481,7 +481,7 @@ class IoTAClient(BaseHttpClient):
             devices = self.get_device_list(entity_names=[device.entity_name])
             if len(devices) > 0 and not force_entity_deletion:
                 raise Exception(f"The Corresponding Entity to the device "
-                                "{device_id} is linked to multiple devices, "
+                                f"{device_id} is linked to multiple devices, "
                                 "it was not deleted")
             else:
                 try:

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -364,12 +364,10 @@ class IoTAClient(BaseHttpClient):
         Returns:
 
         """
-        for key, conditions in locals().items():
-            if key in ["devices"]:
-                continue
-            if not conditions:
-                continue
-            devices = [device for device in devices if device.dict()[key] in conditions]
+        if entity_name:
+            devices = [device for device in devices if device.entity_name in entity_name]
+        if entity_type:
+            devices = [device for device in devices if device.entity_type in entity_type]
         return devices
 
     def get_device(self, *, device_id: str) -> Device:

--- a/filip/utils/iot.py
+++ b/filip/utils/iot.py
@@ -7,7 +7,8 @@ from filip.models.ngsi_v2.iot import Device
 
 def filter_device_list(devices: List[Device],
                        entity_name: List[str] = None,
-                       entity_type: List[str] = None) -> List[Device]:
+                       entity_type: List[str] = None,
+                       device_id: List[str] =None) -> List[Device]:
     """
     Filter the given device list based on conditions
 
@@ -15,6 +16,7 @@ def filter_device_list(devices: List[Device],
         devices: device list that need to be filtered
         entity_name: A list of entity_name (e.g. entity_id) as filter condition
         entity_type: A list of entity_type as filter condition
+        device_id: A list of device_id as filter condition
 
     Returns:
 
@@ -23,4 +25,6 @@ def filter_device_list(devices: List[Device],
         devices = [device for device in devices if device.entity_name in entity_name]
     if entity_type:
         devices = [device for device in devices if device.entity_type in entity_type]
+    if device_id:
+        devices = [device for device in devices if device.device_id in device_id]
     return devices

--- a/filip/utils/iot.py
+++ b/filip/utils/iot.py
@@ -1,0 +1,26 @@
+"""
+Helper functions to handle the devices related with the IoT Agent
+"""
+from typing import List
+from filip.models.ngsi_v2.iot import Device
+
+
+def filter_device_list(devices: List[Device],
+                       entity_name: List[str] = None,
+                       entity_type: List[str] = None) -> List[Device]:
+    """
+    Filter the given device list based on conditions
+
+    Args:
+        devices: device list that need to be filtered
+        entity_name: A list of entity_name (e.g. entity_id) as filter condition
+        entity_type: A list of entity_type as filter condition
+
+    Returns:
+
+    """
+    if entity_name:
+        devices = [device for device in devices if device.entity_name in entity_name]
+    if entity_type:
+        devices = [device for device in devices if device.entity_type in entity_type]
+    return devices

--- a/filip/utils/iot.py
+++ b/filip/utils/iot.py
@@ -1,30 +1,48 @@
 """
 Helper functions to handle the devices related with the IoT Agent
 """
-from typing import List
+from typing import List, Union
 from filip.models.ngsi_v2.iot import Device
 
 
 def filter_device_list(devices: List[Device],
-                       entity_name: List[str] = None,
-                       entity_type: List[str] = None,
-                       device_id: List[str] =None) -> List[Device]:
+                       device_ids: Union[str, List[str]] = None,
+                       entity_names: Union[str, List[str]] = None,
+                       entity_types: Union[str, List[str]] = None) -> List[Device]:
     """
     Filter the given device list based on conditions
 
     Args:
         devices: device list that need to be filtered
-        entity_name: A list of entity_name (e.g. entity_id) as filter condition
-        entity_type: A list of entity_type as filter condition
-        device_id: A list of device_id as filter condition
+        device_ids: A list of device_id as filter condition
+        entity_names: A list of entity_name (e.g. entity_id) as filter condition.
+        entity_types: A list of entity_type as filter condition
 
     Returns:
-
+        List of matching devices
     """
-    if entity_name:
-        devices = [device for device in devices if device.entity_name in entity_name]
-    if entity_type:
-        devices = [device for device in devices if device.entity_type in entity_type]
-    if device_id:
-        devices = [device for device in devices if device.device_id in device_id]
+    if device_ids:
+        if isinstance(device_ids, (list, str)):
+            if isinstance(device_ids, str):
+                device_ids = [device_ids]
+            devices = [device for device in devices if device.device_id in device_ids]
+        else:
+            raise TypeError('device_ids must be a string or a list of strings!')
+
+    if entity_names:
+        if isinstance(entity_names, (list, str)):
+            if isinstance(entity_names, str):
+                entity_names = [entity_names]
+            devices = [device for device in devices if device.entity_name in entity_names]
+        else:
+            raise TypeError('entity_names must be a string or a list of strings!')
+
+    if entity_types:
+        if isinstance(entity_types, (list, str)):
+            if isinstance(entity_types, str):
+                entity_types = [entity_types]
+            devices = [device for device in devices if device.entity_type in entity_types]
+        else:
+            raise TypeError('entity_types must be a string or a list of strings!')
+
     return devices

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -803,16 +803,10 @@ class TestContextBroker(unittest.TestCase):
             )
             devices.append(device)
         self.iotac.post_devices(devices=devices)
-
-        # delete an entity and the related device one by one
-        n_devices = 20
-        while True:
-            if not devices:
-                break
+        while devices:
             device = devices.pop()
-            n_devices += -1
             self.client.delete_entity(entity_id=device.entity_name, entity_type=device.entity_type, delete_devices=True)
-            self.assertEqual(len(self.iotac.get_device_list()), n_devices)
+            self.assertEqual(len(self.iotac.get_device_list()), len(devices))
 
     def tearDown(self) -> None:
         """

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 from requests import RequestException
 from filip.models.base import FiwareHeader
 from filip.utils.simple_ql import QueryString
-from filip.clients.ngsi_v2 import ContextBrokerClient
+from filip.clients.ngsi_v2 import ContextBrokerClient, IoTAClient
 from filip.clients.ngsi_v2 import HttpClient, HttpClientConfig
 from filip.config import settings
 from filip.models.ngsi_v2.context import \
@@ -68,6 +68,9 @@ class TestContextBroker(unittest.TestCase):
                                      'type': 'Number'}}
         self.entity = ContextEntity(id='MyId', type='MyType', **self.attr)
 
+        self.iotac = IoTAClient(
+            url=settings.IOTA_JSON_URL,
+            fiware_header=self.fiware_header)
 
         self.client = ContextBrokerClient(
             url=settings.CB_URL,
@@ -772,6 +775,44 @@ class TestContextBroker(unittest.TestCase):
         self.assertEqual(result_entity,
                          self.client.get_entity(entity_id=entity.id))
         self.tearDown()
+
+    def test_delete_entity_devices(self):
+        # create devices
+        base_device_id = "device:"
+
+        base_entity_id_1 = "urn:ngsi-ld:TemperatureSensor:"
+        entity_type_1 = "TemperatureSensor"
+
+        base_entity_id_2 = "urn:ngsi-ld:HumiditySensor:"
+        entity_type_2 = "HumiditySensor"
+
+        devices = []
+
+        for i in range(20):
+            base_entity_id = base_entity_id_1 if i < 10 else base_entity_id_2
+            entity_type = entity_type_1 if i < 10 else entity_type_2
+
+            device_id = base_device_id + str(i)
+            entity_id = base_entity_id + str(i)
+            device = Device(
+                service=settings.FIWARE_SERVICE,
+                service_path=settings.FIWARE_SERVICEPATH,
+                device_id=device_id,
+                entity_type=entity_type,
+                entity_name=entity_id
+            )
+            devices.append(device)
+        self.iotac.post_devices(devices=devices)
+
+        # delete an entity and the related device one by one
+        n_devices = 20
+        while True:
+            if not devices:
+                break
+            device = devices.pop()
+            n_devices += -1
+            self.client.delete_entity(entity_id=device.entity_name, entity_type=device.entity_type, delete_devices=True)
+            self.assertEqual(len(self.iotac.get_device_list()), n_devices)
 
     def tearDown(self) -> None:
         """

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -408,22 +408,36 @@ class TestAgent(unittest.TestCase):
         self.assertEqual(len(filter_device_list(devices)), len(devices))
 
         # test with entity type
-        self.assertEqual(len(filter_device_list(devices, entity_type=[entity_type_1])),
+        self.assertEqual(len(filter_device_list(devices, entity_types=[entity_type_1])),
                          10)
-        self.assertEqual(len(filter_device_list(devices, entity_type=[entity_type_1, entity_type_2])),
+        self.assertEqual(len(filter_device_list(devices, entity_types=[entity_type_1, entity_type_2])),
                          20)
 
         # test with entity id
-        self.assertEqual(len(filter_device_list(devices, entity_name=entity_id_list[5:])),
+        self.assertEqual(len(filter_device_list(devices, entity_names=entity_id_list[5:])),
                          len(entity_id_list[5:]))
 
         # test with entity type and entity id
-        self.assertEqual(len(filter_device_list(devices, entity_name=entity_id_list, entity_type=[entity_type_1])),
+        self.assertEqual(len(filter_device_list(devices, entity_names=entity_id_list, entity_types=[entity_type_1])),
                          10)
 
         # test with device id
-        self.assertEqual(len(filter_device_list(devices, device_id=device_id_list[5:])),
+        self.assertEqual(len(filter_device_list(devices, device_ids=device_id_list[5:])),
                          len(device_id_list[5:]))
+
+        # test with single args
+        self.assertEqual(len(filter_device_list(devices,
+                                                device_ids=devices[0].device_id,
+                                                entity_names=devices[0].entity_name,
+                                                entity_types=devices[0].entity_type)), 1)
+
+        # test for errors
+        with self.assertRaises(TypeError):
+            filter_device_list(devices, device_ids={'1234'})
+        with self.assertRaises(TypeError):
+            filter_device_list(devices, entity_names={'1234'})
+        with self.assertRaises(TypeError):
+            filter_device_list(devices, entity_types={'1234'})
 
     def tearDown(self) -> None:
         """

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -402,6 +402,7 @@ class TestAgent(unittest.TestCase):
             devices.append(device)
 
         entity_id_list = [device.entity_name for device in devices]
+        device_id_list = [device.device_id for device in devices]
 
         # test with no inputs
         self.assertEqual(len(filter_device_list(devices)), len(devices))
@@ -419,6 +420,10 @@ class TestAgent(unittest.TestCase):
         # test with entity type and entity id
         self.assertEqual(len(filter_device_list(devices, entity_name=entity_id_list, entity_type=[entity_type_1])),
                          10)
+
+        # test with device id
+        self.assertEqual(len(filter_device_list(devices, device_id=device_id_list[5:])),
+                         len(device_id_list[5:]))
 
     def tearDown(self) -> None:
         """

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -370,6 +370,57 @@ class TestAgent(unittest.TestCase):
             self.assertEqual(live_device.__getattribute__(key), value)
             cb_client.close()
 
+    def test_filter_device_list(self) -> None:
+        """
+        Test the function filter_device_list
+        """
+        # create devices
+        base_device_id = "device:"
+
+        base_entity_id_1 = "urn:ngsi-ld:TemperatureSensor:"
+        entity_type_1 = "TemperatureSensor"
+
+        base_entity_id_2 = "urn:ngsi-ld:HumiditySensor:"
+        entity_type_2 = "HumiditySensor"
+
+        devices = []
+
+        for i in range(20):
+            base_entity_id = base_entity_id_1 if i < 10 else base_entity_id_2
+            entity_type = entity_type_1 if i < 10 else entity_type_2
+
+            device_id = base_device_id + str(i)
+            entity_id = base_entity_id + str(i)
+            device = Device(
+                service=settings.FIWARE_SERVICE,
+                service_path=settings.FIWARE_SERVICEPATH,
+                device_id=device_id,
+                entity_type=entity_type,
+                entity_name=entity_id
+            )
+            devices.append(device)
+
+        entity_id_list = [device.entity_name for device in devices]
+
+        # test with no inputs
+        self.assertEqual(len(self.client.filter_device_list(devices)), len(devices))
+
+        # test with entity type
+        self.assertEqual(len(self.client.filter_device_list(devices, entity_type=[entity_type_1])),
+                         10)
+        self.assertEqual(len(self.client.filter_device_list(devices, entity_type=[entity_type_1, entity_type_2])),
+                         20)
+
+        # test with entity id
+        self.assertEqual(len(self.client.filter_device_list(devices, entity_name=entity_id_list[5:])),
+                         len(entity_id_list[5:]))
+
+        # test with entity type and entity id
+        self.assertEqual(len(self.client.filter_device_list(devices,
+                                                            entity_name=entity_id_list,
+                                                            entity_type=[entity_type_1])),
+                         10)
+
     def tearDown(self) -> None:
         """
         Cleanup test server
@@ -378,9 +429,3 @@ class TestAgent(unittest.TestCase):
         clear_all(fiware_header=self.fiware_header,
                   cb_url=settings.CB_URL,
                   iota_url=settings.IOTA_JSON_URL)
-
-    def test_filter_device_list(self) -> None:
-        """
-        Test the function filter_device_list
-        """
-        pass

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -21,6 +21,7 @@ from filip.models.ngsi_v2.iot import \
     StaticDeviceAttribute
 from filip.utils.cleanup import clear_all, clean_test
 from tests.config import settings
+from filip.utils.iot import filter_device_list
 
 
 logger = logging.getLogger(__name__)
@@ -403,22 +404,20 @@ class TestAgent(unittest.TestCase):
         entity_id_list = [device.entity_name for device in devices]
 
         # test with no inputs
-        self.assertEqual(len(self.client.filter_device_list(devices)), len(devices))
+        self.assertEqual(len(filter_device_list(devices)), len(devices))
 
         # test with entity type
-        self.assertEqual(len(self.client.filter_device_list(devices, entity_type=[entity_type_1])),
+        self.assertEqual(len(filter_device_list(devices, entity_type=[entity_type_1])),
                          10)
-        self.assertEqual(len(self.client.filter_device_list(devices, entity_type=[entity_type_1, entity_type_2])),
+        self.assertEqual(len(filter_device_list(devices, entity_type=[entity_type_1, entity_type_2])),
                          20)
 
         # test with entity id
-        self.assertEqual(len(self.client.filter_device_list(devices, entity_name=entity_id_list[5:])),
+        self.assertEqual(len(filter_device_list(devices, entity_name=entity_id_list[5:])),
                          len(entity_id_list[5:]))
 
         # test with entity type and entity id
-        self.assertEqual(len(self.client.filter_device_list(devices,
-                                                            entity_name=entity_id_list,
-                                                            entity_type=[entity_type_1])),
+        self.assertEqual(len(filter_device_list(devices, entity_name=entity_id_list, entity_type=[entity_type_1])),
                          10)
 
     def tearDown(self) -> None:

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -427,6 +427,15 @@ class TestAgent(unittest.TestCase):
 
         # test with single args
         self.assertEqual(len(filter_device_list(devices,
+                                                device_ids=devices[0].device_id)), 1)
+
+        self.assertEqual(len(filter_device_list(devices,
+                                                entity_names=devices[0].entity_name)), 1)
+
+        self.assertNotEqual(len(filter_device_list(devices,
+                                                   entity_types=devices[0].entity_type)), 1)
+
+        self.assertEqual(len(filter_device_list(devices,
                                                 device_ids=devices[0].device_id,
                                                 entity_names=devices[0].entity_name,
                                                 entity_types=devices[0].entity_type)), 1)

--- a/tests/clients/test_ngsi_v2_iota.py
+++ b/tests/clients/test_ngsi_v2_iota.py
@@ -378,3 +378,9 @@ class TestAgent(unittest.TestCase):
         clear_all(fiware_header=self.fiware_header,
                   cb_url=settings.CB_URL,
                   iota_url=settings.IOTA_JSON_URL)
+
+    def test_filter_device_list(self) -> None:
+        """
+        Test the function filter_device_list
+        """
+        pass


### PR DESCRIPTION
Since the IoTAgent API does not provide filter functionality, I implement this in the IoTAgentClient of FiLiP. In this way the function get_device_list( ) can now return the devices filtered by entity_id.