### PR TITLE
fix: added override_metadata args to patch_entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,6 @@ venv
 /filip/external_resources/unece-units-of-measure.hdf
 /external_resources/
 
-/examples/data_models/
+/examples/ngsi_v2/data_models/
 /tests/semantics/models.py
 /tests/semantics/models2.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 #### v0.2.3
+- added `override_metadata` argument according to new metadata update semantics in orion (https://fiware-orion.readthedocs.io/en/master/user/metadata.html#updating-metadata) ([#157](https://github.com/RWTH-EBC/FiLiP/issues/157))
+- fixed test for patch_entity ([#157](https://github.com/RWTH-EBC/FiLiP/issues/157))
 - fixed issue of client generation when multiple clients are required ([#151](https://github.com/RWTH-EBC/FiLiP/issues/151))
 - fixed throttling=0 is not working when posting a subscription ([#148](https://github.com/RWTH-EBC/FiLiP/issues/148))
 - added filter functions for better subscription handling ([#141](https://github.com/RWTH-EBC/FiLiP/issues/141))

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -1663,6 +1663,8 @@ class ContextBrokerClient(BaseHttpClient):
             old_entity: OPTIONAL, if given only the differences between the
                        old_entity and entity are updated in the CB.
                        Other changes made to the entity in CB, can be kept.
+                       If type or id was changed, the old_entity will be
+                       deleted.
             override_attr_metadata:
                 Whether to override or append the attributes metadata.
                 `True` for overwrite or `False` for update/append
@@ -1697,7 +1699,7 @@ class ContextBrokerClient(BaseHttpClient):
 
             # if type or id was changed, the old_entity needs to be deleted
             # and the new_entity created
-            # In this case we will loose the current state of the entity
+            # In this case we will lose the current state of the entity
             if old_entity.id != new_entity.id or \
                     old_entity.type != new_entity.type:
                 self.delete_entity(entity_id=old_entity.id,

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -191,20 +191,36 @@ class ContextBrokerClient(BaseHttpClient):
     # Entity Operations
     def post_entity(self,
                     entity: ContextEntity,
-                    update: bool = False):
+                    update: bool = False,
+                    patch: bool = False,
+                    override_attr_metadata: bool = True
+                    ):
         """
         Function registers an Object with the NGSI Context Broker,
-        if it already exists it can be automatically updated
-        if the overwrite bool is True
+        if it already exists it can be automatically updated (overwritten)
+        if the update bool is True.
         First a post request with the entity is tried, if the response code
         is 422 the entity is uncrossable, as it already exists there are two
         options, either overwrite it, if the attribute have changed
         (e.g. at least one new/new values) (update = True) or leave
         it the way it is (update=False)
+        If you only want to manipulate the entities values, you need to set
+        patch argument.
+
         Args:
-            update (bool): If the response.status_code is 422, whether the old
-            entity should be updated or not
-            entity (ContextEntity): Context Entity Object
+            entity (ContextEntity):
+                Context Entity Object
+            update (bool):
+                If the response.status_code is 422, whether the override and
+                existing entity
+            patch (bool):
+                If the response.status_code is 422, whether the manipulate the
+                existing entity. Omitted if update `True`.
+            override_attr_metadata:
+                Only applies for patch equal to `True`.
+                Whether to override or append the attributes metadata.
+                `True` for overwrite or `False` for update/append
+
         """
         url = urljoin(self.base_url, 'v2/entities')
         headers = self.headers.copy()
@@ -221,7 +237,12 @@ class ContextBrokerClient(BaseHttpClient):
             res.raise_for_status()
         except requests.RequestException as err:
             if update and err.response.status_code == 422:
-                return self.update_entity(entity=entity)
+                return self.update_entity(
+                    entity=entity)
+            if patch and err.response.status_code == 422:
+                return self.patch_entity(
+                    entity=entity,
+                    override_attr_metadata=override_attr_metadata)
             msg = f"Could not post entity {entity.id}"
             self.log_error(err=err, msg=msg)
             raise
@@ -237,7 +258,7 @@ class ContextBrokerClient(BaseHttpClient):
                         georel: str = None,
                         geometry: str = None,
                         coords: str = None,
-                        limit: int = inf,
+                        limit: PositiveInt = inf,
                         attrs: List[str] = None,
                         metadata: str = None,
                         order_by: str = None,
@@ -496,10 +517,15 @@ class ContextBrokerClient(BaseHttpClient):
 
     def update_entity(self,
                       entity: ContextEntity,
-                      append_strict: bool = False):
+                      append_strict: bool = False
+                      ):
         """
         The request payload is an object representing the attributes to
         append or update.
+
+        Note:
+            Update means overwriting the existing entity. If you want to
+            manipulate you should rather use patch_entity.
 
         Args:
             entity (ContextEntity):
@@ -511,8 +537,9 @@ class ContextBrokerClient(BaseHttpClient):
                 to that, in case some of the attributes in the payload
                 already exist in the entity, an error is returned.
                 More precisely this means a strict append procedure.
-        Returns:
 
+        Returns:
+            None
         """
         self.update_or_append_entity_attributes(entity_id=entity.id,
                                                 entity_type=entity.type,
@@ -834,15 +861,27 @@ class ContextBrokerClient(BaseHttpClient):
                                             NamedContextAttribute],
                                 *,
                                 entity_type: str = None,
-                                attr_name: str = None):
+                                attr_name: str = None,
+                                override_metadata: bool = True):
         """
         Updates a specified attribute from an entity.
 
         Args:
-            attr: context attribute to update
-            entity_id: Id of the entity. Example: Bcn_Welt
-            entity_type: Entity type, to avoid ambiguity in case there are
-            several entities with the same entity id.
+            attr:
+                context attribute to update
+            entity_id:
+                Id of the entity. Example: Bcn_Welt
+            entity_type:
+                Entity type, to avoid ambiguity in case there are
+                several entities with the same entity id.
+            override_metadata:
+                Bool, if set to `True` (default) the metadata will be
+                overwritten. This is for backwards compatibility reasons.
+                If `False` the metadata values will be either updated if
+                already existing or append if not.
+                See also:
+                https://fiware-orion.readthedocs.io/en/master/user/metadata.html
+
         """
         headers = self.headers.copy()
         if not isinstance(attr, NamedContextAttribute):
@@ -860,9 +899,13 @@ class ContextBrokerClient(BaseHttpClient):
         params = {}
         if entity_type:
             params.update({'type': entity_type})
+        # set overrideMetadata option (we assure backwards compatibility here)
+        if override_metadata:
+            params.update({'options': 'overrideMetadata'})
         try:
             res = self.put(url=url,
                            headers=headers,
+                           params=params,
                            json=attr.dict(exclude={'name'},
                                           exclude_unset=True,
                                           exclude_none=True))
@@ -1604,15 +1647,21 @@ class ContextBrokerClient(BaseHttpClient):
 
     def patch_entity(self,
                      entity: ContextEntity,
-                     old_entity: Optional[ContextEntity] = None) -> None:
+                     old_entity: Optional[ContextEntity] = None,
+                     override_attr_metadata: bool = True) -> None:
         """
         Takes a given entity and updates the state in the CB to match it.
+        It is an extended equivalent to the HTTP method PATCH, which applies
+        partial modifications to a resource.
 
         Args:
-           entity: Entity to update
-           old_entity: OPTIONAL, if given only the differences between the
+            entity: Entity to update
+            old_entity: OPTIONAL, if given only the differences between the
                        old_entity and entity are updated in the CB.
                        Other changes made to the entity in CB, can be kept.
+            override_attr_metadata:
+                Whether to override or append the attributes metadata.
+                `True` for overwrite or `False` for update/append
 
         Returns:
            None
@@ -1638,7 +1687,8 @@ class ContextBrokerClient(BaseHttpClient):
             # and discard old_entity
             if not self.does_entity_exists(entity_id=old_entity.id,
                                            entity_type=old_entity.type):
-                self.patch_entity(new_entity)
+                self.patch_entity(new_entity,
+                                  override_attr_metadata=override_attr_metadata)
                 return
 
             # if type or id was changed, the old_entity needs to be deleted
@@ -1686,12 +1736,14 @@ class ContextBrokerClient(BaseHttpClient):
             else:
                 # Check if attributed changed in any way, if yes update
                 # else do nothing and keep current state
-                if not old_attr.__eq__(corresponding_new_attr):
+                if old_attr != corresponding_new_attr:
                     try:
                         self.update_entity_attribute(
                             entity_id=new_entity.id,
                             entity_type=new_entity.type,
-                            attr=corresponding_new_attr)
+                            attr=corresponding_new_attr,
+                            override_metadata=override_attr_metadata
+                        )
                     except requests.RequestException as err:
                         # if the attribute is provided by a registration the
                         # update will fail

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -691,6 +691,7 @@ class TestContextBroker(unittest.TestCase):
     def test_patch_entity(self) -> None:
         """
         Test the methode: patch_entity
+
         Returns:
            None
         """
@@ -705,46 +706,45 @@ class TestContextBroker(unittest.TestCase):
             NamedMetadata(name="meta2", type="metatype", value="3")
         entity.add_attributes([attr1, attr2])
 
-        # sub-Test1: Post new
+        # sub-Test1: Post new. No old entity not exist or is provided!
         self.client.patch_entity(entity=entity)
         self.assertEqual(entity,
                          self.client.get_entity(entity_id=entity.id))
         self.tearDown()
 
-        # sub-Test2: ID/type of old_entity changed
+        # sub-Test2: ID/type of old_entity changed. Old entity is provided and
+        # updated!
         self.client.post_entity(entity=entity)
         test_entity = ContextEntity(id="newID", type="newType")
         test_entity.add_attributes([attr1, attr2])
         self.client.patch_entity(test_entity, old_entity=entity)
         self.assertEqual(test_entity,
                          self.client.get_entity(entity_id=test_entity.id))
+        # assert that former entity_id is freed again
         self.assertRaises(RequestException, self.client.get_entity,
                           entity_id=entity.id)
         self.tearDown()
 
-        # sub-Test3: a non valid old_entity is provided, entity exists
+        # sub-Test3: a non valid old_entity is provided, but already entity
+        # exists
         self.client.post_entity(entity=entity)
         old_entity = ContextEntity(id="newID", type="newType")
-
         self.client.patch_entity(entity, old_entity=old_entity)
         self.assertEqual(entity, self.client.get_entity(entity_id=entity.id))
         self.tearDown()
 
-        # sub-Test4: no old_entity provided, entity is new
+        # sub-Test4: non valid old_entity provided, entity is new
         old_entity = ContextEntity(id="newID", type="newType")
         self.client.patch_entity(entity, old_entity=old_entity)
         self.assertEqual(entity, self.client.get_entity(entity_id=entity.id))
         self.tearDown()
 
-        # sub-Test5: no old_entity provided, entity is new
-        old_entity = ContextEntity(id="newID", type="newType")
-        self.client.patch_entity(entity, old_entity=old_entity)
-        self.assertEqual(entity, self.client.get_entity(entity_id=entity.id))
-        self.tearDown()
-
-        # sub-Test6: New attr, attr del, and attr changed. No Old_entity given
+        # sub-Test5: New attr, attr del, and attr changed. No Old_entity given
         self.client.post_entity(entity=entity)
         test_entity = ContextEntity(id="test_id1", type="test_type1")
+        # check if the test_entity corresponds to the original entity
+        self.assertEqual(test_entity.id, entity.id)
+        self.assertEqual(test_entity.type, entity.type)
         attr1_changed = NamedContextAttribute(name="attr1", value="2")
         attr1_changed.metadata["m4"] = \
             NamedMetadata(name="meta3", type="metatype5", value="4")
@@ -756,7 +756,7 @@ class TestContextBroker(unittest.TestCase):
                          self.client.get_entity(entity_id=entity.id))
         self.tearDown()
 
-        # sub-Test7: Attr changes, concurrent changes in Fiware,
+        # sub-Test6: Attr changes, concurrent changes in Fiware,
         #            old_entity given
 
         self.client.post_entity(entity=entity)

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -721,8 +721,8 @@ class TestContextBroker(unittest.TestCase):
         self.assertEqual(test_entity,
                          self.client.get_entity(entity_id=test_entity.id))
         # assert that former entity_id is freed again
-        self.assertRaises(RequestException, self.client.get_entity,
-                          entity_id=entity.id)
+        with self.assertRaises(RequestException):
+            self.client.get_entity(entity_id=entity.id)
         self.tearDown()
 
         # sub-Test3: a non valid old_entity is provided, but already entity


### PR DESCRIPTION
For #157

In the new orion version from 3.6.0 the update semantics of attribute metadata has introduced a breaking change. Also see: https://github.com/telefonicaid/fiware-orion/issues/4033 and https://fiware-orion.readthedocs.io/en/master/user/metadata.html#updating-metadata