### PR TITLE
145 update relationships with contextbrokerclient update entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### v0.4.2
 - add: validation for JEXL based expression ([#260](https://github.com/RWTH-EBC/FiLiP/pull/260))
 - add: tutorials for multi-entity ([#260](https://github.com/RWTH-EBC/FiLiP/pull/260))
+- add: add ``update_entity_relationships`` to allow relationship update ([#271](https://github.com/RWTH-EBC/FiLiP/pull/271))
 
 ### v0.4.1
 - fix: Session added as optional parameter to enable tls communication with clients ([#249](https://github.com/RWTH-EBC/FiLiP/pull/249))

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -549,7 +549,67 @@ class ContextBrokerClient(BaseHttpClient):
         self.update_or_append_entity_attributes(
             entity_id=entity.id,
             entity_type=entity.type,
+            attrs=entity.get_attributes(),
+            append_strict=append_strict,
+        )
+
+    def update_entity_properties(self, entity: ContextEntity, append_strict: bool = False):
+        """
+        The request payload is an object representing the attributes, of any type
+        but Relationship, to append or update.
+
+        Note:
+            Update means overwriting the existing entity. If you want to
+            manipulate you should rather use patch_entity.
+
+        Args:
+            entity (ContextEntity):
+            append_strict: If `False` the entity attributes are updated (if they
+                previously exist) or appended (if they don't previously exist)
+                with the ones in the payload.
+                If `True` all the attributes in the payload not
+                previously existing in the entity are appended. In addition
+                to that, in case some of the attributes in the payload
+                already exist in the entity, an error is returned.
+                More precisely this means a strict append procedure.
+
+        Returns:
+            None
+        """
+        self.update_or_append_entity_attributes(
+            entity_id=entity.id,
+            entity_type=entity.type,
             attrs=entity.get_properties(),
+            append_strict=append_strict,
+        )
+
+    def update_entity_relationships(self, entity: ContextEntity, append_strict: bool = False):
+        """
+        The request payload is an object representing only the attributes, of type
+        Relationship, to append or update.
+
+        Note:
+            Update means overwriting the existing entity. If you want to
+            manipulate you should rather use patch_entity.
+
+        Args:
+            entity (ContextEntity):
+            append_strict: If `False` the entity attributes are updated (if they
+                previously exist) or appended (if they don't previously exist)
+                with the ones in the payload.
+                If `True` all the attributes in the payload not
+                previously existing in the entity are appended. In addition
+                to that, in case some of the attributes in the payload
+                already exist in the entity, an error is returned.
+                More precisely this means a strict append procedure.
+
+        Returns:
+            None
+        """
+        self.update_or_append_entity_attributes(
+            entity_id=entity.id,
+            entity_type=entity.type,
+            attrs=entity.get_relationships(),
             append_strict=append_strict,
         )
 

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -583,7 +583,8 @@ class ContextBrokerClient(BaseHttpClient):
             append_strict=append_strict,
         )
 
-    def update_entity_relationships(self, entity: ContextEntity, append_strict: bool = False):
+    def update_entity_relationships(self, entity: ContextEntity,
+                                    append_strict: bool = False):
         """
         The request payload is an object representing only the attributes, of type
         Relationship, to append or update.

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -398,7 +398,7 @@ class TestContextBroker(unittest.TestCase):
                 # post entity with a relationship attribute
                 entity_init = self.entity.model_copy(deep=True)
                 attrs = [
-                    NamedContextAttribute(name='in', type='Relationship', value='B1')]
+                    NamedContextAttribute(name='in', type='Relationship', value='dummy1')]
                 entity_init.add_attributes(attrs=attrs)
                 client.post_entity(entity=entity_init, update=True)
 
@@ -406,9 +406,9 @@ class TestContextBroker(unittest.TestCase):
                 entity_update = entity_init.model_copy(deep=True)
                 attrs = [NamedContextAttribute(name='temperature',
                                                type='Number',
-                                               value='2.0'),
+                                               value=21),
                          NamedContextAttribute(name='in', type='Relationship',
-                                               value='B2')]
+                                               value='dummy2')]
                 entity_update.update_attribute(attrs=attrs)
 
                 # update only properties and compare
@@ -421,9 +421,9 @@ class TestContextBroker(unittest.TestCase):
                 update_attrs = entity_update.get_attribute(attribute_name='in')
                 self.assertNotEqual(db_attrs, update_attrs)
 
-                # change property, update relationship, compare
+                # update only relationship and compare
                 attrs = [
-                    NamedContextAttribute(name='temperature', type='Number', value=50.0)]
+                    NamedContextAttribute(name='temperature', type='Number', value=22)]
                 entity_update.update_attribute(attrs=attrs)
                 client.update_entity_relationships(entity_update)
                 entity_db = client.get_entity(entity_update.id)
@@ -434,16 +434,20 @@ class TestContextBroker(unittest.TestCase):
                                         attribute_name='temperature'))
 
                 # change both, update both, compare
-                client.update_entity(entity_init)
-                entity_db = client.get_entity(entity_init.id)
+                attrs = [NamedContextAttribute(name='temperature',
+                                               type='Number',
+                                               value=23),
+                         NamedContextAttribute(name='in', type='Relationship',
+                                               value='dummy3')]
+                entity_update.update_attribute(attrs=attrs)
+                client.update_entity(entity_update)
+                entity_db = client.get_entity(entity_update.id)
                 db_attrs = entity_db.get_attribute(attribute_name='in')
                 update_attrs = entity_update.get_attribute(attribute_name='in')
-                self.assertNotEqual(db_attrs, update_attrs)
+                self.assertEqual(db_attrs, update_attrs)
                 db_attrs = entity_db.get_attribute(attribute_name='temperature')
                 update_attrs = entity_update.get_attribute(attribute_name='temperature')
-                self.assertNotEqual(db_attrs, update_attrs)
-                clear_all(fiware_header=self.fiware_header,
-                          cb_url=settings.CB_URL)
+                self.assertEqual(db_attrs, update_attrs)
 
     @clean_test(fiware_service=settings.FIWARE_SERVICE,
                 fiware_servicepath=settings.FIWARE_SERVICEPATH,

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -261,10 +261,10 @@ class TestContextBroker(unittest.TestCase):
             entity_init = self.entity.model_copy(deep=True)
             attr_init = entity_init.get_attribute("temperature")
             attr_init.metadata = {
-                    "metadata_init": {
-                        "type": "Text",
-                        "value": "something"}
-                }
+                "metadata_init": {
+                    "type": "Text",
+                    "value": "something"}
+            }
             attr_append = NamedContextAttribute(**{
                 "name": 'pressure',
                 "type": 'Number',
@@ -392,52 +392,56 @@ class TestContextBroker(unittest.TestCase):
                                  entity_patch)
                 clear_all(fiware_header=self.fiware_header,
                           cb_url=settings.CB_URL)
-            
+
             # 4) update only property or relationship
             if "update_entity_properties" or "update_entity_relationship":
-                #post entity with a relationship attribute
+                # post entity with a relationship attribute
                 entity_init = self.entity.model_copy(deep=True)
-                attrs =[NamedContextAttribute(name='in',type='Relationship',value='B1')]
+                attrs = [
+                    NamedContextAttribute(name='in', type='Relationship', value='B1')]
                 entity_init.add_attributes(attrs=attrs)
                 client.post_entity(entity=entity_init, update=True)
 
-                #create entity that differs in both attributes
+                # create entity that differs in both attributes
                 entity_update = entity_init.model_copy(deep=True)
                 attrs = [NamedContextAttribute(name='temperature',
                                                type='Number',
                                                value='2.0'),
-                         NamedContextAttribute(name='in',type='Relationship',value='B2')]
+                         NamedContextAttribute(name='in', type='Relationship',
+                                               value='B2')]
                 entity_update.update_attribute(attrs=attrs)
 
-                #update only properties and compare
+                # update only properties and compare
                 client.update_entity_properties(entity_update)
                 entity_db = client.get_entity(entity_update.id)
                 db_attrs = entity_db.get_attribute(attribute_name='temperature')
                 update_attrs = entity_update.get_attribute(attribute_name='temperature')
-                self.assertEqual(db_attrs,update_attrs)
+                self.assertEqual(db_attrs, update_attrs)
                 db_attrs = entity_db.get_attribute(attribute_name='in')
                 update_attrs = entity_update.get_attribute(attribute_name='in')
-                self.assertNotEqual(db_attrs,update_attrs)
+                self.assertNotEqual(db_attrs, update_attrs)
 
-                #change property, update relationship, compare
-                attrs=[NamedContextAttribute(name='temperature',type='Number',value=50.0)]
+                # change property, update relationship, compare
+                attrs = [
+                    NamedContextAttribute(name='temperature', type='Number', value=50.0)]
                 entity_update.update_attribute(attrs=attrs)
                 client.update_entity_relationships(entity_update)
                 entity_db = client.get_entity(entity_update.id)
                 self.assertEqual(entity_db.get_attribute(attribute_name='in'),
-                            entity_update.get_attribute(attribute_name='in'))
+                                 entity_update.get_attribute(attribute_name='in'))
                 self.assertNotEqual(entity_db.get_attribute(attribute_name='temperature'),
-                            entity_update.get_attribute(attribute_name='temperature'))
-    
-                #change both, update both, compare
+                                    entity_update.get_attribute(
+                                        attribute_name='temperature'))
+
+                # change both, update both, compare
                 client.update_entity(entity_init)
                 entity_db = client.get_entity(entity_init.id)
                 db_attrs = entity_db.get_attribute(attribute_name='in')
                 update_attrs = entity_update.get_attribute(attribute_name='in')
-                self.assertNotEqual(db_attrs,update_attrs)
+                self.assertNotEqual(db_attrs, update_attrs)
                 db_attrs = entity_db.get_attribute(attribute_name='temperature')
                 update_attrs = entity_update.get_attribute(attribute_name='temperature')
-                self.assertNotEqual(db_attrs,update_attrs)
+                self.assertNotEqual(db_attrs, update_attrs)
                 clear_all(fiware_header=self.fiware_header,
                           cb_url=settings.CB_URL)
 
@@ -1460,9 +1464,11 @@ class TestContextBroker(unittest.TestCase):
         self.client.post_entity(entity=entity)
 
         testData = "hello_test"
-        self.client.update_attribute_value(entity_id="string_test", attr_name="data", value=testData)
+        self.client.update_attribute_value(entity_id="string_test", attr_name="data",
+                                           value=testData)
 
-        readback = self.client.get_attribute_value(entity_id="string_test", attr_name="data")
+        readback = self.client.get_attribute_value(entity_id="string_test",
+                                                   attr_name="data")
 
         self.assertEqual(testData, readback)
 


### PR DESCRIPTION
Closes #145 Update Relationships with ContextBrokerClient update_entity. Implemented as suggested in the issue. The test is standalone for now but maybe it should be incorporated in the update_entity case of test_entity_update ?