### PR TITLE
272 mqtt v2 does not work

### DIFF
--- a/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
+++ b/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
         logger.info("Received this message:\n" + message.json(indent=2))
 
 
-    def on_disconnect(client, userdata, reasonCode, properties=None):
+    def on_disconnect(client, userdata, flags, reasonCode, properties=None):
         logger.info("MQTT client disconnected with reasonCode "
                     + str(reasonCode))
 

--- a/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
+++ b/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
                              "type": "Integer"}
                 }
     room_entity = ContextEntity(**room_001)
-    cb_client.post_entity(entity=room_entity)
+    cb_client.post_entity(entity=room_entity, update=True)
 
 
     # # 2 Setup a subscription and MQTT notifications

--- a/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
+++ b/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
 
     mqtt_client = mqtt.Client(userdata=None,
                               protocol=mqtt.MQTTv5,
-                              callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+                              callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                               transport="tcp")
     # add callbacks to the mqtt-client
     mqtt_client.on_connect = on_connect

--- a/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
+++ b/examples/ngsi_v2/e04_ngsi_v2_context_subscriptions_mqtt.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
 
     mqtt_client = mqtt.Client(userdata=None,
                               protocol=mqtt.MQTTv5,
+                              callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
                               transport="tcp")
     # add callbacks to the mqtt-client
     mqtt_client.on_connect = on_connect

--- a/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
+++ b/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
                              f"/{device.device_id}/cmdexe",
                        payload=json.dumps(res))
 
-    def on_disconnect(client, userdata, reasonCode, properties):
+    def on_disconnect(client, userdata, flags, reasonCode, properties):
         logger.info("MQTT client disconnected" + str(reasonCode))
 
     mqtt_client = mqtt.Client(client_id="filip-iot-example",

--- a/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
+++ b/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
@@ -207,7 +207,7 @@ if __name__ == '__main__':
     mqtt_client = mqtt.Client(client_id="filip-iot-example",
                               userdata=None,
                               protocol=mqtt.MQTTv5,
-                              callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+                              callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                               transport="tcp")
     # add our callbacks to the client
     mqtt_client.on_connect = on_connect

--- a/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
+++ b/examples/ngsi_v2/e08_ngsi_v2_iota_paho_mqtt.py
@@ -207,6 +207,7 @@ if __name__ == '__main__':
     mqtt_client = mqtt.Client(client_id="filip-iot-example",
                               userdata=None,
                               protocol=mqtt.MQTTv5,
+                              callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
                               transport="tcp")
     # add our callbacks to the client
     mqtt_client.on_connect = on_connect

--- a/examples/ngsi_v2/e09_ngsi_v2_iota_filip_mqtt.py
+++ b/examples/ngsi_v2/e09_ngsi_v2_iota_filip_mqtt.py
@@ -104,10 +104,10 @@ if __name__ == '__main__':
     def on_connect_fail(mqttc, obj):
         mqttc.logger.info("Connect failed")
 
-    def on_publish(mqttc, obj, mid,rc,properties=None):
+    def on_publish(mqttc, obj, mid, rc, properties=None):
         mqttc.logger.info("mid: " + str(mid))
 
-    def on_subscribe(mqttc, obj, mid, granted_qos,properties=None):
+    def on_subscribe(mqttc, obj, mid, granted_qos, properties=None):
         mqttc.logger.info("Subscribed: " + str(mid)
                           + " " + str(granted_qos))
 

--- a/examples/ngsi_v2/e09_ngsi_v2_iota_filip_mqtt.py
+++ b/examples/ngsi_v2/e09_ngsi_v2_iota_filip_mqtt.py
@@ -98,16 +98,16 @@ if __name__ == '__main__':
     #
     mqttc = IoTAMQTTClient()
 
-    def on_connect(mqttc, obj, flags, rc):
+    def on_connect(mqttc, obj, flags, rc, properties=None):
         mqttc.logger.info("rc: " + str(rc))
 
     def on_connect_fail(mqttc, obj):
         mqttc.logger.info("Connect failed")
 
-    def on_publish(mqttc, obj, mid):
+    def on_publish(mqttc, obj, mid,rc,properties=None):
         mqttc.logger.info("mid: " + str(mid))
 
-    def on_subscribe(mqttc, obj, mid, granted_qos):
+    def on_subscribe(mqttc, obj, mid, granted_qos,properties=None):
         mqttc.logger.info("Subscribed: " + str(mid)
                           + " " + str(granted_qos))
 

--- a/filip/clients/mqtt/client.py
+++ b/filip/clients/mqtt/client.py
@@ -7,6 +7,7 @@ import logging
 import warnings
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Tuple, Union
+
 import paho.mqtt.client as mqtt
 
 from filip.clients.mqtt.encoder import BaseEncoder, Json, Ultralight
@@ -126,6 +127,7 @@ class IoTAMQTTClient(mqtt.Client):
                  userdata=None,
                  protocol=mqtt.MQTTv311,
                  transport="tcp",
+                 callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                  devices: List[Device] = None,
                  service_groups: List[ServiceGroup] = None,
                  custom_encoder: Dict[str, BaseEncoder] = None):
@@ -188,6 +190,7 @@ class IoTAMQTTClient(mqtt.Client):
                          clean_session=clean_session,
                          userdata=userdata,
                          protocol=protocol,
+                         callback_api_version=callback_api_version,
                          transport=transport)
 
         # setup logging functionality

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -827,7 +827,7 @@ class ContextBrokerClient(BaseHttpClient):
         The entity attributes are updated with the ones in the payload.
         In addition to that, if one or more attributes in the payload doesn't
         exist in the entity, an error is returned. This corresponds to a
-        'PATcH' request.
+        'PATCH' request.
 
         Args:
             entity_id: Entity id to be updated

--- a/filip/clients/ngsi_v2/cb.py
+++ b/filip/clients/ngsi_v2/cb.py
@@ -2027,12 +2027,6 @@ class ContextBrokerClient(BaseHttpClient):
                     continue
                 else:
                     return False
-            if not _value_is_not_none(v) or not _value_is_not_none(ex_value):
-                warnings.warn(
-                    "Different field found:{"
-                    f"{k}: ({v}, {ex_value})"
-                    "}"
-                )
             if v != ex_value:
                 self.logger.debug(f"Not equal fields for key {k}: ({v}, {ex_value})")
                 if not _value_is_not_none(v) and not _value_is_not_none(ex_value) or k == "timesSent":

--- a/filip/clients/ngsi_v2/iota.py
+++ b/filip/clients/ngsi_v2/iota.py
@@ -286,6 +286,7 @@ class IoTAClient(BaseHttpClient):
             devices = [devices]
         url = urljoin(self.base_url, 'iot/devices')
         headers = self.headers
+        
         data = {"devices": [json.loads(device.model_dump_json(exclude_none=True)
                                        ) for device in devices]}
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-Levenshtein~=0.23.0
 python-dateutil~=2.8.2
 wget~=3.2
 stringcase~=1.2.0
-paho-mqtt>=2.0.0
+paho-mqtt~=2.0.0
 datamodel_code_generator[http]~=0.25.0
 # tutorials
 matplotlib~=3.5.3; python_version < '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-Levenshtein~=0.23.0
 python-dateutil~=2.8.2
 wget~=3.2
 stringcase~=1.2.0
-paho-mqtt~=1.6.1
+paho-mqtt>=2.0.0
 datamodel_code_generator[http]~=0.25.0
 # tutorials
 matplotlib~=3.5.3; python_version < '3.9'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = readme_path.read_text()
 
 INSTALL_REQUIRES = ['aenum~=3.1.15',
                     'datamodel_code_generator[http]~=0.25.0',
-                    'paho-mqtt>=2.0.0',
+                    'paho-mqtt~=2.0.0',
                     'pandas_datapackage_reader~=0.18.0',
                     'pydantic~=2.5.2',
                     'pydantic-settings~=2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,11 @@ LONG_DESCRIPTION = readme_path.read_text()
 
 INSTALL_REQUIRES = ['aenum~=3.1.15',
                     'datamodel_code_generator[http]~=0.25.0',
-                    'paho-mqtt~=1.6.1',
+                    'paho-mqtt>=2.0.0',
                     'pandas_datapackage_reader~=0.18.0',
                     'pydantic~=2.5.2',
                     'pydantic-settings~=2.0.0',
+                    'geojson_pydantic~=1.0.2',
                     'stringcase>=1.2.0',
                     'rdflib~=6.0.0',
                     'regex~=2023.10.3',

--- a/tests/clients/test_mqtt_client.py
+++ b/tests/clients/test_mqtt_client.py
@@ -61,16 +61,16 @@ class TestMQTTClient(unittest.TestCase):
 
         self.mqttc = IoTAMQTTClient()
 
-        def on_connect(mqttc, obj, flags, rc):
+        def on_connect(mqttc, obj, flags, rc,properties):
             mqttc.logger.info("rc: " + str(rc))
 
         def on_connect_fail(mqttc, obj):
             mqttc.logger.info("Connect failed")
 
-        def on_publish(mqttc, obj, mid):
+        def on_publish(mqttc, obj, mid,rc,properties):
             mqttc.logger.info("mid: " + str(mid))
 
-        def on_subscribe(mqttc, obj, mid, granted_qos):
+        def on_subscribe(mqttc, obj, mid, granted_qos,properties):
             mqttc.logger.info("Subscribed: " + str(mid)
                               + " " + str(granted_qos))
 

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -652,7 +652,7 @@ class TestContextBroker(unittest.TestCase):
             nonlocal sub_message
             sub_message = Message.model_validate_json(msg.payload)
 
-        def on_disconnect(client, userdata, reasonCode, properties=None):
+        def on_disconnect(client, userdata, flags, reasonCode, properties=None):
             logger.info("MQTT client disconnected with reasonCode "
                         + str(reasonCode))
 
@@ -846,7 +846,7 @@ class TestContextBroker(unittest.TestCase):
             sub_message = Message.model_validate_json(msg.payload)
             sub_messages[sub_message.subscriptionId] = sub_message
 
-        def on_disconnect(client, userdata, reasonCode, properties=None):
+        def on_disconnect(client, userdata, flags, reasonCode, properties=None):
             logger.info("MQTT client disconnected with reasonCode "
                         + str(reasonCode))
 
@@ -1222,7 +1222,7 @@ class TestContextBroker(unittest.TestCase):
                                  f"/{device.device_id}/cmdexe",
                            payload=json.dumps(res))
 
-        def on_disconnect(client, userdata, reasonCode, properties=None):
+        def on_disconnect(client, userdata, flags, reasonCode, properties=None):
             pass
 
         mqtt_client = mqtt.Client(client_id="filip-test",

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -659,6 +659,7 @@ class TestContextBroker(unittest.TestCase):
         import paho.mqtt.client as mqtt
         mqtt_client = mqtt.Client(userdata=None,
                                   protocol=mqtt.MQTTv5,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
                                   transport="tcp")
         # add our callbacks to the client
         mqtt_client.on_connect = on_connect
@@ -852,6 +853,7 @@ class TestContextBroker(unittest.TestCase):
         import paho.mqtt.client as mqtt
         mqtt_client = mqtt.Client(userdata=None,
                                   protocol=mqtt.MQTTv5,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
                                   transport="tcp")
         # add our callbacks to the client
         mqtt_client.on_connect = on_connect
@@ -1226,6 +1228,7 @@ class TestContextBroker(unittest.TestCase):
         mqtt_client = mqtt.Client(client_id="filip-test",
                                   userdata=None,
                                   protocol=mqtt.MQTTv5,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
                                   transport="tcp")
 
         # add our callbacks to the client

--- a/tests/clients/test_ngsi_v2_cb.py
+++ b/tests/clients/test_ngsi_v2_cb.py
@@ -659,7 +659,7 @@ class TestContextBroker(unittest.TestCase):
         import paho.mqtt.client as mqtt
         mqtt_client = mqtt.Client(userdata=None,
                                   protocol=mqtt.MQTTv5,
-                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                                   transport="tcp")
         # add our callbacks to the client
         mqtt_client.on_connect = on_connect
@@ -853,7 +853,7 @@ class TestContextBroker(unittest.TestCase):
         import paho.mqtt.client as mqtt
         mqtt_client = mqtt.Client(userdata=None,
                                   protocol=mqtt.MQTTv5,
-                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                                   transport="tcp")
         # add our callbacks to the client
         mqtt_client.on_connect = on_connect
@@ -1228,7 +1228,7 @@ class TestContextBroker(unittest.TestCase):
         mqtt_client = mqtt.Client(client_id="filip-test",
                                   userdata=None,
                                   protocol=mqtt.MQTTv5,
-                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION1,
+                                  callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                                   transport="tcp")
 
         # add our callbacks to the client

--- a/tests/models/test_ngsi_v2_iot.py
+++ b/tests/models/test_ngsi_v2_iot.py
@@ -6,6 +6,7 @@ import unittest
 from typing import List
 import warnings
 from paho.mqtt import client as mqtt_client
+from paho.mqtt.client import CallbackAPIVersion
 import pyjexl
 
 from filip.models.base import FiwareHeader
@@ -163,7 +164,7 @@ class TestContextv2IoTModels(unittest.TestCase):
                          )
         self.iota_client.post_device(device=device1)
 
-        mqtt_cl = mqtt_client.Client()
+        mqtt_cl = mqtt_client.Client(callback_api_version=CallbackAPIVersion.VERSION2)
         mqtt_cl.connect(settings.MQTT_BROKER_URL.host, settings.MQTT_BROKER_URL.port)
         mqtt_cl.loop_start()
 

--- a/tutorials/ngsi_v2/e1_virtual_weatherstation/e1_virtual_weatherstation_solution.py
+++ b/tutorials/ngsi_v2/e1_virtual_weatherstation/e1_virtual_weatherstation_solution.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     history_weather_station = []
 
     # ToDo: create a MQTTv5 client with paho-mqtt
-    mqttc = mqtt.Client(protocol=mqtt.MQTTv5, callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
+    mqttc = mqtt.Client(protocol=mqtt.MQTTv5, callback_api_version=mqtt.CallbackAPIVersion.VERSION2)
     # set user data if required
     mqttc.username_pw_set(username=MQTT_USER, password=MQTT_PW)
     # ToDo: Define a callback function that will be executed when the client

--- a/tutorials/ngsi_v2/e1_virtual_weatherstation/e1_virtual_weatherstation_solution.py
+++ b/tutorials/ngsi_v2/e1_virtual_weatherstation/e1_virtual_weatherstation_solution.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     history_weather_station = []
 
     # ToDo: create a MQTTv5 client with paho-mqtt
-    mqttc = mqtt.Client(protocol=mqtt.MQTTv5)
+    mqttc = mqtt.Client(protocol=mqtt.MQTTv5, callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
     # set user data if required
     mqttc.username_pw_set(username=MQTT_USER, password=MQTT_PW)
     # ToDo: Define a callback function that will be executed when the client


### PR DESCRIPTION
Closes #272 
Closes #270 

I also removed a redundant warning in the subscription handling, which leads to this messages:

```
18-Apr-2024 12:32:58 INFO: pong/NotifiedAttributesContextBroker: Posting subscription to topic '/agentlib/agentlib/myEmulatorExample/ContextBrokerSubscriptions/pong_NotifiedAttributesContextBroker' with sub'={"id":null,"description":"pong_NotifiedAttributesContextBroker","status":"active","subject":{"entities":[{"id":"ping_entity","idPattern":null,"type":"sensor","typePattern":null}],"condition":{"attrs":["ping_attribute"],"expression":null}},"notification":{"timesSent":null,"http":null,"httpCustom":null,"mqtt":{"url":"mqtt://134.130.56.157:1883","topic":"/agentlib/agentlib/myEmulatorExample/ContextBrokerSubscriptions/pong_NotifiedAttributesContextBroker/ping_entity","qos":0,"user":null,"passwd":null},"mqttCustom":null,"attrs":null,"exceptAttrs":null,"attrsFormat":"normalized","metadata":null,"onlyChangedAttrs":false},"expires":null,"throttling":null}'
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{expression: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{timesSent: (None, 4)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{http: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{httpCustom: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{qos: (0, 0)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{user: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{passwd: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{mqttCustom: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{attrs: (None, [])}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{exceptAttrs: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{metadata: (None, None)}
  warnings.warn(
d:\01_projekte\02_dzwi\filip\filip\clients\ngsi_v2\cb.py:2031: UserWarning: Different field found:{onlyChangedAttrs: (False, False)}
  warnings.warn(
```
However, the lines below already if both are None and handle them correctly:
```
            if v != ex_value:
                self.logger.debug(f"Not equal fields for key {k}: ({v}, {ex_value})")
                if not _value_is_not_none(v) and not _value_is_not_none(ex_value) or k == "timesSent":
                    continue
                return False
```