### PR TITLE
288 filip support right now only paylaod in mqtt custom / http custom but orion already supports json and ngsi as further options

### DIFF
--- a/filip/models/ngsi_v2/subscriptions.py
+++ b/filip/models/ngsi_v2/subscriptions.py
@@ -27,6 +27,8 @@ import warnings
 # The pydantic models still have a .json() function, but this method is deprecated.
 warnings.filterwarnings("ignore", category=UserWarning,
                         message='Field name "json" shadows an attribute in parent "Http"')
+warnings.filterwarnings("ignore", category=UserWarning,
+                        message='Field name "json" shadows an attribute in parent "Mqtt"')
 
 
 class NgsiPayloadAttr(BaseValueAttribute):
@@ -38,7 +40,8 @@ class NgsiPayloadAttr(BaseValueAttribute):
     representations ( as specified in the orion api manual), done by the BaseValueAttr.
     model.
     """
-    model_config=ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid")
+
 
 class NgsiPayload(BaseModel):
     """
@@ -65,10 +68,9 @@ class NgsiPayload(BaseModel):
 
     @model_validator(mode='after')
     def validate_notification_attrs(self):
-        for v in self.model_dump(exclude={"id","type"}).values():
-            assert isinstance(NgsiPayloadAttr.model_validate(v),NgsiPayloadAttr)
+        for v in self.model_dump(exclude={"id", "type"}).values():
+            assert isinstance(NgsiPayloadAttr.model_validate(v), NgsiPayloadAttr)
         return self
-
 
 
 class Message(BaseModel):
@@ -129,7 +131,7 @@ class HttpCustom(Http):
         description='get a json as notification. If omitted, the default'
                     'payload (see "Notification Messages" sections) is used.'
     )
-    ngsi:Optional[NgsiPayload] = Field(
+    ngsi: Optional[NgsiPayload] = Field(
         default=None,
         description='get an NGSI-v2 normalized entity as notification.If omitted, '
                     'the default payload (see "Notification Messages" sections) is used.'
@@ -208,20 +210,21 @@ class MqttCustom(Mqtt):
                     'default payload (see "Notification Messages" sections) '
                     'is used.'
     )
-    json: Optional[Dict[str,Any]] = Field(
+    json: Optional[Dict[str, Any]] = Field(
         default=None,
         description='get a json as notification. If omitted, the default'
                     'payload (see "Notification Messages" sections) is used.'
     )
-    ngsi:Optional[NgsiPayload] = Field(
+    ngsi: Optional[NgsiPayload] = Field(
         default=None,
         description='get an NGSI-v2 normalized entity as notification.If omitted, '
                     'the default payload (see "Notification Messages" sections) is used.'
     )
+
     @model_validator(mode='after')
     def validate_payload_type(self):
         assert len([v for k, v in self.model_dump().items()
-                    if((v is not None) and (k in ['payload','ngsi','json']))]) <= 1
+                    if ((v is not None) and (k in ['payload', 'ngsi', 'json']))]) <= 1
         return self
 
 

--- a/filip/models/ngsi_v2/subscriptions.py
+++ b/filip/models/ngsi_v2/subscriptions.py
@@ -136,10 +136,11 @@ class HttpCustom(Http):
     )
     timeout: Optional[int] = Field(
         default=None,
-        description="Maximum time (in milliseconds) the subscription waits for the response. The maximum value allowed "
-                    "for this parameter is 1800000 (30 minutes). If timeout is defined to 0 or omitted, then the value "
-                    "passed as -httpTimeout CLI parameter is used. See section in the 'Command line options' for more "
-                    "details."
+        description="Maximum time (in milliseconds) the subscription waits for the "
+                    "response. The maximum value allowed for this parameter is 1800000 "
+                    "(30 minutes). If timeout is defined to 0 or omitted, then the value "
+                    "passed as -httpTimeout CLI parameter is used. See section in the "
+                    "'Command line options' for more details."
     )
 
     @model_validator(mode='after')
@@ -148,7 +149,8 @@ class HttpCustom(Http):
         filled_fields = [field for field in fields if field is not None]
 
         if len(filled_fields) > 1:
-            raise ValueError("Only one of payload, json or ngsi fields accepted at the same time in httpCustom.")
+            raise ValueError("Only one of payload, json or ngsi fields accepted at the "
+                             "same time in httpCustom.")
 
         return self
 

--- a/filip/models/ngsi_v2/subscriptions.py
+++ b/filip/models/ngsi_v2/subscriptions.py
@@ -24,7 +24,7 @@ from filip.models.ngsi_v2.base import (
 from filip.custom_types import AnyMqttUrl
 
 
-class NotificationAttr(BaseValueAttribute):
+class NgsiPayloadAttr(BaseValueAttribute):
     """
     Model for NGSI V2 type payload in httpCustom/mqttCustom notifications.
     The difference between this model and the usual BaseValueAttribute model is that
@@ -35,15 +35,12 @@ class NotificationAttr(BaseValueAttribute):
     """
     model_config=ConfigDict(extra="forbid")
 
-class NotificationEntity(BaseModel):
+class NgsiPayload(BaseModel):
     """
     Model for NGSI V2 type payload in httpCustom/mqttCustom notifications.
     Differences between this model and the usual Context entity models include:
         - id and type are not mandatory
-        - a metadata Attribute field is not allowed
-    In the absence of type/value in some attribute field, one should resort to partial 
-    representations ( as specified in the orion api manual), done by the BaseValueAttr.
-    model.
+        - an attribute metadata field is not allowed
     """
     model_config = ConfigDict(
         extra="allow", validate_default=True
@@ -64,7 +61,7 @@ class NotificationEntity(BaseModel):
     @model_validator(mode='after')
     def validate_notification_attrs(self):
         for v in self.model_dump(exclude={"id","type"}).values():
-            assert isinstance(NotificationAttr.model_validate(v),NotificationAttr)
+            assert isinstance(NgsiPayloadAttr.model_validate(v),NgsiPayloadAttr)
         return self
     
 
@@ -127,7 +124,7 @@ class HttpCustom(Http):
         description='get a json as notification. If omitted, the default'
                     'payload (see "Notification Messages" sections) is used.'
     )
-    ngsi:Optional[NotificationEntity] = Field(
+    ngsi:Optional[NgsiPayload] = Field(
         default=None,
         description='get an NGSI-v2 normalized entity as notification.If omitted, '
                     'the default payload (see "Notification Messages" sections) is used.'
@@ -198,7 +195,7 @@ class MqttCustom(Mqtt):
         description='get a json as notification. If omitted, the default'
                     'payload (see "Notification Messages" sections) is used.'
     )
-    ngsi:Optional[NotificationEntity] = Field(
+    ngsi:Optional[NgsiPayload] = Field(
         default=None,
         description='get an NGSI-v2 normalized entity as notification.If omitted, '
                     'the default payload (see "Notification Messages" sections) is used.'

--- a/tests/models/test_ngsi_v2_subscriptions.py
+++ b/tests/models/test_ngsi_v2_subscriptions.py
@@ -145,7 +145,8 @@ class TestSubscriptions(unittest.TestCase):
         Returns:
             None
         """
-        sub = Subscription.model_validate(self.sub_dict)
+        tmp_dict=self.sub_dict.copy()
+        sub = Subscription.model_validate(tmp_dict)
         fiware_header = FiwareHeader(service=settings.FIWARE_SERVICE,
                                      service_path=settings.FIWARE_SERVICEPATH)
         with ContextBrokerClient(
@@ -161,6 +162,65 @@ class TestSubscriptions(unittest.TestCase):
                     else:
                         self.assertEqual(str(value), str(dict2[key]))
 
+            compare_dicts(sub.model_dump(exclude={'id'}),
+                          sub_res.model_dump(exclude={'id'}))
+            
+            tmp_dict.update({"notification":{
+                "httpCustom": {
+                    "url": "http://localhost:1234",
+                    "ngsi":{
+                        "patchattr":{
+                            "value":"${temperature/2}",
+                            "type":"Calculated"
+                        }
+                    },
+                    "method":"POST"
+                },
+                "attrs": [
+                    "temperature",
+                    "humidity"
+                ]
+            }})
+            sub = Subscription.model_validate(tmp_dict)
+            sub_id = client.post_subscription(subscription=sub)
+            sub_res = client.get_subscription(subscription_id=sub_id)
+            compare_dicts(sub.model_dump(exclude={'id'}),
+                          sub_res.model_dump(exclude={'id'}))
+            
+            tmp_dict.update({"notification":{
+                "httpCustom": {
+                    "url": "http://localhost:1234",
+                    "json":{
+                        "t":"${temperate}",
+                        "h":"${humidity}"
+                    },
+                    "method":"POST"
+                },
+                "attrs": [
+                    "temperature",
+                    "humidity"
+                ]
+            }})
+            sub = Subscription.model_validate(tmp_dict)
+            sub_id = client.post_subscription(subscription=sub)
+            sub_res = client.get_subscription(subscription_id=sub_id)
+            compare_dicts(sub.model_dump(exclude={'id'}),
+                          sub_res.model_dump(exclude={'id'}))
+
+            tmp_dict.update({"notification":{
+                "httpCustom": {
+                    "url": "http://localhost:1234",
+                    "payload":"Temperature is ${temperature} and humidity ${humidity}",
+                    "method":"POST"
+                },
+                "attrs": [
+                    "temperature",
+                    "humidity"
+                ]
+            }})
+            sub = Subscription.model_validate(tmp_dict)
+            sub_id = client.post_subscription(subscription=sub)
+            sub_res = client.get_subscription(subscription_id=sub_id)
             compare_dicts(sub.model_dump(exclude={'id'}),
                           sub_res.model_dump(exclude={'id'}))
 

--- a/tests/models/test_ngsi_v2_subscriptions.py
+++ b/tests/models/test_ngsi_v2_subscriptions.py
@@ -12,7 +12,9 @@ from filip.models.ngsi_v2.subscriptions import \
     Mqtt, \
     MqttCustom, \
     Notification, \
-    Subscription
+    Subscription, \
+    NgsiPayload, \
+    NgsiPayloadAttr
 from filip.models.base import FiwareHeader
 from filip.utils.cleanup import clear_all, clean_test
 from tests.config import settings
@@ -104,6 +106,27 @@ class TestSubscriptions(unittest.TestCase):
             notification.mqtt = mqtt
         with self.assertRaises(ValidationError):
             notification.mqtt = mqttCustom
+        with self.assertRaises(ValidationError):
+            HttpCustom(url=self.http_url,json={},payload="")
+        with self.assertRaises(ValidationError):
+            MqttCustom(url=self.mqtt_url,
+                       topic=self.mqtt_topic,ngsi=NgsiPayload(),payload="")
+        with self.assertRaises(ValidationError):
+            HttpCustom(url=self.http_url,ngsi=NgsiPayload(),json="")
+        
+        #Test validator for ngsi payload type
+        with self.assertRaises(ValidationError):
+            attr_dict={
+                "metadata":{}
+            }
+            NgsiPayloadAttr(**attr_dict)
+        with self.assertRaises(ValidationError):
+            attr_dict={
+                "id":"entityId",
+                "type":"entityType",
+                "k":"v"
+            }
+            NgsiPayload(NgsiPayloadAttr(**attr_dict),id="someId",type="someType")
 
         # test onlyChangedAttrs-field
         notification = Notification.model_validate(self.notification)


### PR DESCRIPTION
The following warning pops up "UserWarning: Field name "json" shadows an attribute in parent "Mqtt"" ( due to the json fields in MqttCustom and HttpCustom ). Since the Http/Mqtt models do not have an explicit json field, i take it this is coming from some field/property in the base model.
Tried to circumvent the warning by the use of aliases which obviously did not work.

Not sure what model to specify for the json payload type, i just put a Dict[str, any] for now ( despite number/string being valid json , the orion manual specifies that it needs to be a JSON object and not an object of primitive type )

Any input on these two points is welcome.